### PR TITLE
[Tests] Fix validation_flush_tests on 64bit builds.

### DIFF
--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     // CCoinsCacheView, so it's sort of arbitrary - but it shouldn't change
     // unless we somehow change the way the cacheCoins map allocates memory.
     //
-    constexpr int COINS_UNTIL_CRITICAL = is_64_bit ? 3 : 3;
+    constexpr int COINS_UNTIL_CRITICAL = is_64_bit ? 2 : 3;
 
     for (int i{0}; i < COINS_UNTIL_CRITICAL; ++i) {
         COutPoint res = add_coin(view);


### PR DESCRIPTION
The validation_flush_tests test in test was failing on my pc.While logging i found that the coins_until_critical should be 2 for 64 bit hosts/builds.

This PR changes the COINS_UNTIL_CRITICAL to 2 for 64 bit hosts/builds and 3 for 32 bit hosts/builds. 
 Closes #1 