### PR TITLE
Add Particl to COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2020 The Ghost Developers
+Copyright (c) 2017-2020 The Particl Developers
+Copyright (c)    2020   The Ghost Developers
 Copyright (c) 2009-2020 The Bitcoin Core developers
 Copyright (c) 2009-2020 Bitcoin Developers
 


### PR DESCRIPTION
Self explanatory PR.Adds particl to COPYING which is used when viewing the license of the repo.