### PR TITLE
Change bech32 address prefixes

### DIFF
--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -70,9 +70,9 @@ bech32_templates = [
   ('pw',    0, 20, (False, 'main',    None, True), p2wpkh_prefix),
   ('pw',    0, 32, (False, 'main',    None, True), p2wsh_prefix),
   ('pw',    1,  2, (False, 'main',    None, True), (OP_1, 2)),
-  ('tgw',    0, 20, (False, 'test',    None, True), p2wpkh_prefix),
-  ('tgw',    0, 32, (False, 'test',    None, True), p2wsh_prefix),
-  ('tgw',    2, 16, (False, 'test',    None, True), (OP_2, 16)),
+  ('tgstw', 0, 20, (False, 'test',    None, True), p2wpkh_prefix),
+  ('tgstw', 0, 32, (False, 'test',    None, True), p2wsh_prefix),
+  ('tgstw', 2, 16, (False, 'test',    None, True), (OP_2, 16)),
   ('rtpw',  0, 20, (False, 'regtest', None, True), p2wpkh_prefix),
   ('rtpw',  0, 32, (False, 'regtest', None, True), p2wsh_prefix),
   ('rtpw', 16, 40, (False, 'regtest', None, True), (OP_16, 40))
@@ -81,13 +81,13 @@ bech32_templates = [
 bech32_ng_templates = [
   # hrp, version, witprog_size, invalid_bech32, invalid_checksum, invalid_char
   ('tc',    0, 20, False, False, False),
-  ('tgw',   17, 32, False, False, False),
+  ('tgstw',   17, 32, False, False, False),
   ('rtpw',  3,  1, False, False, False),
   ('pw',   15, 41, False, False, False),
-  ('tgw',    0, 16, False, False, False),
+  ('tgstw',    0, 16, False, False, False),
   ('rtpw',  0, 32, True,  False, False),
   ('pw',    0, 16, True,  False, False),
-  ('tgw',    0, 32, False, True,  False),
+  ('tgstw',    0, 32, False, True,  False),
   ('rtpw',  0, 20, False, False, True)
 ]
 

--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -108,7 +108,7 @@ def is_valid(v):
 
 def is_valid_bech32(v):
     '''Check vector v for bech32 validity'''
-    for hrp in ['pw', 'tgw', 'rtpw']:
+    for hrp in ['pw', 'tgstw', 'rtpw']:
         if decode(hrp, v) != (None, None):
             return True
     return False

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -677,17 +677,17 @@ public:
 
         {
             std::map<int, std::string> bech32PrefixesMap{
-                {PUBKEY_ADDRESS, "tgh"},
-                {SCRIPT_ADDRESS,"tgr"},
-                {PUBKEY_ADDRESS_256,"tgl"},
-                {SCRIPT_ADDRESS_256,"tgj"},
-                {SECRET_KEY,"tgx"},
-                {EXT_PUBLIC_KEY,"tgep"},
-                {EXT_SECRET_KEY,"tgex"},
-                {STEALTH_ADDRESS,"tgs"},
-                {EXT_KEY_HASH,"tgek"},
-                {EXT_ACC_HASH,"tgea"},
-                {STAKE_ONLY_PKADDR,"tgcs"},
+                {PUBKEY_ADDRESS, "tgsth"},
+                {SCRIPT_ADDRESS,"tgstr"},
+                {PUBKEY_ADDRESS_256,"tgstl"},
+                {SCRIPT_ADDRESS_256,"tgstj"},
+                {SECRET_KEY,"tgstx"},
+                {EXT_PUBLIC_KEY,"tgstep"},
+                {EXT_SECRET_KEY,"tgstex"},
+                {STEALTH_ADDRESS,"tgsts"},
+                {EXT_KEY_HASH,"tgstek"},
+                {EXT_ACC_HASH,"tgstea"},
+                {STAKE_ONLY_PKADDR,"tgstcs"},
             };
 
             for(auto&& p: bech32PrefixesMap)
@@ -696,7 +696,7 @@ public:
             }
         }
 
-        bech32_hrp = "tgw";
+        bech32_hrp = "tgstw";
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 

--- a/src/test/data/key_io_invalid.json
+++ b/src/test/data/key_io_invalid.json
@@ -6,147 +6,147 @@
         "x"
     ],
     [
-        "U17TNQ6WMNxJtF586cHmkGHaDuvdUrUpdypmYCb4jFjAnFaGJbUfDrHrb4TSTZ5MS9NB3spzE28"
+        "4d8zQHRGBsEM5oDM9PxWS6CXDd5cThouDhygDwF4AM3CJt1Q2gCp"
     ],
     [
-        "FQvHaoG9EdsxPafL8ESYUFyWDrfevG77yh"
+        "2zz4A6RSmJJsGXutw33cyamBgWTniRfnAHgHV86wJA1Zk9Sm74C"
     ],
     [
-        "7wGy6x9FJYqEyRS9LzyVUkujzytQ1XhiwiY4irwDG3ctD6GwoWDW"
+        "HawnNccY4eAftYiXHivq4G5PrgrDBjV8jA8FkdmP5Mz339g3HEAZA686wPMVCFv6B3L45V4dQsv"
     ],
     [
-        "tc1qqamywnjgl7vdrkph6e583xe97p2xl23upu56s0"
+        "tc1qffxp8qa79nzajxlu6alrj7nv4ks645ly4ejk4m"
     ],
     [
-        "tgw130k4wjxftlmuytedlsvxweplul5640eff47mcvqmcmal00dukdkkqv7gmm6"
+        "tgstw137swvxnn988c55rr4afcf498x79w0ty99l5s3au0f425w9mtmxa7s2h499c"
     ],
     [
-        "rtpw1r5ugdad3z"
+        "rtpw1r8qmfyxu8"
     ],
     [
-        "pw1097evlfusa9yhgkwstug9vrv9g06q0zqxqdh880swlrtpypyavjpe0pe8qh2hu69kevs7x8zq"
+        "pw10xcfxkrtrg7l4dle4pwp4uc3c3nsp3rwdmcaqc9fjde5rhatkyutr86ej0dfe2jmzwqzvqtwq"
     ],
     [
-        "tgw1q9gn5egdye89dzg8mt7j0wfku8c9gmkwr"
+        "tgstw1q7hcvetxycxeeg7edjpykyyltcgvzj0nm"
     ],
     [
-        "rtpw1q4n9f4e8tsgjj029dlc6crwfp8nyxrxagyj09qafupsmnlnzr0gy34lakug"
+        "rtpw1qjvpcv4tpvfehcwjhq9wx6e543tm6ezm049xazyzcsm0chzhvqm83qvnu72"
     ],
     [
-        "pw1qjf7kjcpemh83l49rmlucjaeangqf94ul8"
+        "PW1Q0P8J9ZJ7Y689UEMTGGXSH522RVQGFXX03"
     ],
     [
-        "tgw1q7mnyhr3r8ha7px6s0vyj2nc3k7hpdqh890ejmhu0rppuwar0vafs79xsxh"
+        "tgstw1qvzv32zlernh3a59p985l9w34zl5aze9eanhavpt5dxy4h0dzpdjshr76cv"
     ],
     [
-        "rtpw1qwXTWSkpfpr2ya49ag03jv28cluhagkxk2ysurm"
+        "rtpw1q5s4ugpzg7mxjr5S24Uf6amg6jydn9um3kq9y94"
     ],
     [
-        "2VJgGVijspJJryRe7ZHtUFHsq8C8vcdHxG7"
+        "TuBhrUwYhT1HSw3vtAsbftr7sH6FzAT9M4wea9YLxh7v38nhhP8CdqNUBoTX3ucZdjFyQYb9YgN"
     ],
     [
-        "bhaK2zuvU1Uwp9bQ1jo8dpUQSuHZViMKpK"
+        "pXbtXoiSksnPAXmuiUrADqxQLE6pVHAYt8z"
     ],
     [
-        "aKWai1EpKTP6cMEvKVVxFRqQF8N7BRx8Syr1y4RMVyBP2tFcfgu7"
+        "H6XoFSi3p5NdnZ7mwKSLgB2CeK5rvTRt7a8nB5FPvpEuDxXXrXyH"
     ],
     [
-        "HewKeSkuuWu7Q8jLEbvkW6TNnveGGaEjR1RrckLzc4q49bpca7xDzYnBx2D8ioEPwmktEGPBtWy"
+        "HXMU6xHphjt5s3E7Xsqy6orFeeXntRDxWVzjbmXRc8WkVawpSAYVxTukTD6Mvp2WuN4GCvjJRYn"
     ],
     [
-        "tc1q6d5dtshuxl2zw386cjed6sw3u84dzzz6dtd4vv"
+        "tc1qqpsrapmdvxux2pntv4l26f4efanm545mgslwpy"
     ],
     [
-        "tgw13m7edhlzmt2t48hgrmed52tuansgrqpe4q5h9afantvhh2zxgzhgq4ege8x"
-    ],
-    [
-        "rtpw1ra56645wq"
-    ],
-    [
-        "PW10W7VJUSEPCK9UP52F9QKJ0TCHAQWLX34DCDK3ANC30PMJ35JDG7PF2ZT0RMEXCCWPUYCTVNQC"
-    ],
-    [
-        "tgw1qhu80eplhwtyfysr3mg33j8tv7skqtx5v"
-    ],
-    [
-        "rtpw1qwv7zzfwxyy3mh6xtl5zhs02ksyfghmspewk8ksnaxfmr3jwqwqn34ufkwc"
-    ],
-    [
-        "pw1q9l74cgk4m7hy8rwzdl9emahvwuq6j4dha"
-    ],
-    [
-        "tgw1qhdv946lmdejavh7slufh56n2gy4gn7msxw26xhxan0zhc44u3qwq6qkhsv"
-    ],
-    [
-        "rtpw1q8c3K62Al4zuhuy6hha9gy9d6472lpwqtk43z52"
-    ],
-    [
-        "MDovhbH8QTZjUFeD3QdzsihF6eecPBACdaiuUMb1svrMnTGGnJgnQbCvF5eVGFNv6xnKPSkY7NB"
-    ],
-    [
-        "XJZQapKd3hfMsVCsfcZPGS2futUSnE4ot2"
-    ],
-    [
-        "j9e45eYL7ewfDm6qnw4SS2YAqCFEVEsQav2Hj8K621sSfUVRq1tm1PSXrH77RKYgBCCn2wNMRM1"
-    ],
-    [
-        "kcY4Tuyum4dtxRfAxq8DDqwRcifESCW8a98hXBpRCxBSfLgEWdSaRVgzCBRqvjGAkdD7Xewpmzt"
-    ],
-    [
-        "6LW2e3WqKSHkpxEDQcEDeCzDAXj2Hj68sToJsQx21a1ouA9qbcA"
-    ],
-    [
-        "H7PT2H33Qz6mCUHCiXpSwweRzMEpT2uGNwaVMZzJ2shekjW7Z19k"
-    ],
-    [
-        "7wJkxxx54hik9juRvmBMDpKCiyeKkef7m1BemMveo7TA5VRLu3akx"
-    ],
-    [
-        "4BJ1iApWh3uqr4M4u2pTP4vSEXxpeoPuKv1872RvhaCTVhUUtku"
-    ],
-    [
-        "2G7vxiEEWswWXrLGJYc1LMde2pnNTZTMhDj5DM6TtBr2kx6ZWUNm67vi9nVtW7mEbGKFEh65UtFhX"
-    ],
-    [
-        "tc1qmpdahp38yjn5jc55vh84efxgr905nt4s3f9qnp"
-    ],
-    [
-        "tgw138krhexlmcush4rw6x0hsegn368t0yttdacfh9fst6364ed3sxd3q902we8"
+        "tgstw1308a8aramuscsyvt84kk5gwq2zd3t52fmucujtqh83amjjdf5fylq7fs0cz"
     ],
     [
         "rtpw1rqumh0"
     ],
     [
-        "pw1005qk59d9pcu9283ds2e83kh45ry45fejp8wte7fa4apm9d6r5tgyykgarc8qtd7stgd8xnea"
+        "pw10q9dp5lznv468l0dewqgcne6k3egkc747pnc2nhug9re70xzg0gemjzrvwu68ny800y5q44gh"
     ],
     [
-        "tgw1qqe2mfx7gx2uzy0y83zwewftemyy34mwa"
+        "tgstw1qxwyhhq05lf5p7pxe38ey9x7wac7ev763"
     ],
     [
         "rtpw1rqumh0"
     ],
     [
-        "pw1qsc08vaphaqvdhrhlln5nwg4m0sqxj6qge"
+        "pw1qu725ev3wr9yclegjwupjsq5zsuq4fwh4g"
     ],
     [
-        "TGW1QN6K66D4F5TRWT0PL3VQJ0EPSM469GCZF86DAPF4CCJ3LZ2Q97WRSPN6YTU"
+        "tgstw1uzn7qa"
     ],
     [
-        "rtpw1qu2accz56qR4VJv0tpkz2zy8l4ux0a06czftdq2"
+        "rtpw1qdl2tysmaljk4xv7hyazzf28v3628P3Lk70x0e7"
     ],
     [
-        "2B4PnEXsgdo7pMHszETiZQaLGobPGdZxt57"
+        "255rkZa87CViXDJDMaxUjYQdDzWh9DSKL76"
     ],
     [
-        "3wNF8fYjprvrK9Q22DFBqiP8nNtocVtHiMUAvtb2NWbs59GhFRvHHtJsNnjYP1HWGdBZUNHEFM8BR"
+        "wMz5RRHaMA8cMZZBLkYdeaYGW8NsBSbpBe"
     ],
     [
-        "7r72Hi2dyHEAC2vh5BUo4h33LpmCRKjGGKKTKRRe1aV8ZvMuqYfgk"
+        "txhDzv1C6wtNEN4BukmZY9YC6T8kLaGuv3"
     ],
     [
-        "tc1q6uydea3f0zwkf6wm7zg7mznzwwxaurugx9vm8v"
+        "3wF7NAJBjknkc8ndPMKtA74Nqc1ZVgLBh4UZAZJgbTNRXBRcsHtwKs3a9n9T7Ss3aBY4aXn9io1ER"
     ],
     [
-        "tgw135gy8g5xv96q5fhxv34ax0y8jk03zkmqjjtmhjemgk0dw09w2p2pqdaa3zw"
+        "HRZvQ7o1A2DmcP2RFHENoiW6ji7unPMGmV5Dz3pPwsUYCjXLe4Eakt6Udnk7GHUMZv1D4BqVhAD"
+    ],
+    [
+        "tc1q4mvvrjnhsnw86ex7dql4dcqupl28wjghqcsz98"
+    ],
+    [
+        "tgstw13vvt9juazydltl0wjdgr599v8zhf9uea4pc7w4g0rl3gt76ryr33q2tn5nw"
+    ],
+    [
+        "rtpw1r7c62zezd"
+    ],
+    [
+        "PW106GGF89ZRYNQ8WAE83KHEJFA3LRWNV92MMQ048Q9TW8L5MX6RHDTFWCFD8Z9RJURVFV0QJ0AJ"
+    ],
+    [
+        "tgstw1qrg9xhsg5q25jvv7txnvm24c0mvh3q787"
+    ],
+    [
+        "rtpw1qpypgd9rfcuhnkphr89z3xehzmkyp46fvaae6qphy3m6shjy5fzj32s844v"
+    ],
+    [
+        "pw1qhavrl7u06udv59p9h79tv9z0sqqs5g93u"
+    ],
+    [
+        "tgstw1q5kyg29e5ku2ztxs3tnstur02wr92tegzf0wlaujqar20qennejzq45cq6g"
+    ],
+    [
+        "rtpw1q00gDKSW93h9gxgyzt6lyyex53kfs0u8el8akx0"
+    ],
+    [
+        "TuEaDgxm4ku93VnDgisJeyLs3cg5Bvyt6ns6p4NsNbK6N3SWRwc7ckZYxrw1nrEEJMRkhrTuDSs"
+    ],
+    [
+        "SgckC2a5EAuHH7jhEX5b4NfHFQkmgQnRHN"
+    ],
+    [
+        "2CxeMAdWDTeTM6XQG1hk1JLQLtZcZNdc1fs5zLA9KnHRzyfNV2LGqpSXFpbbw3AWdGGsTqpkuPvTj"
+    ],
+    [
+        "7tX4QCSErBTeVnidqR7ChJZuRotiL2XpZcbD2W6UmHCq9qjVjLRB"
+    ],
+    [
+        "jbWUpPecs8pzutMd6MHHzi5J6vdRnAb5x2Y81X6SX9DiTNX4oppoSzA3aEV5z9DinJm4YQWf4YK"
+    ],
+    [
+        "7ugrUXn5wQEchBTtv8tWw6VwrKfMZfhjWwxy3zffx6M2THycQjnuJ"
+    ],
+    [
+        "tc1q0mlfwz9euy2k9zq32zms2dten46r7zhjdzptef"
+    ],
+    [
+        "tgstw1uzf7qa"
+    ],
+    [
+        "RTPW1RWCULY8KK"
     ]
 ]

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -1,55 +1,55 @@
 [
     [
-        "PvW7Jniuxuea5kU5HV5nSUVxgBffjGpruS",
-        "76a914f7a07e7d19923b58b8f1ad3f323979c68368fa9988ac",
+        "PYUQDGfujFrDGJYgayss3h9e9tecEyRXtw",
+        "76a91405fb01a32a63925b1c01f149651e15b8a754a96788ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "RSZbmAMMEjiYMeWDuhtkPbFAXqNR8mG9oM",
-        "a914bd949051a62fbee5615767239f323b158742c4e487",
+        "REWV2SezYgGCd9ZYveJcv2XvpX551Ne3dm",
+        "a914395c2ede63f9fcfd0f56dc3ec59defe331c41b5f87",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "XUBHT8wsN11cSjW9dBUDTaAhGUczzCFfRy",
-        "76a914b89826dfe65026ccf42a003678f0783687f2de4e88ac",
+        "XUWEsA4scTeEcLretXzGWBdQXQLdKQU73i",
+        "76a914bc2de584405fc30a24530282195d1130463e017088ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "xBbXYPZ21s4TcXd2DeQ96Mf5CCYsNUDHNG",
-        "a914241a253197ab066540d0788f44ce8ca2fc09c86687",
+        "xWQdibr53r9P9apHcM1yvxXGF9m7SDJtK6",
+        "a914f2751d78a7dfb2fa9d305a4d724348411f6ab3d387",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "pZL2JyDiPfjPQhgzTz8K6bG5yjpiemLmEw",
-        "76a91430c3e8871b1758ef50f66c18bfab304508044f7d88ac",
+        "pWXcVb2EqHSXv158HLNz8CE6vCdt9PTE2S",
+        "76a914120ca4205780a465d21f5166ca787ce10450ec5588ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "rPtwgXCEa5qntidkxCpiNDYhYdUwqypwLc",
-        "a914c1bb1ac1866f7650ed662e23a9a8f6e32a2406a587",
+        "rRbXe1d1PtbCCDzJQhoZi6ZzmXihp7gdje",
+        "a914d46036e41fefff032879e2739a9b633ffb9d3e5087",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "4dY5y42N6RSCo8QyYTNh9fDCMoxAdBRasZgJjMDDQNR9Px7Gh7b",
-        "4ec384494be8159d13e6d01d0e52e9cfcfd81afdc21b9b1c514554ea94857030",
+        "4encvtSwnT1dq3tmZRJWH6CFfgojp9A81GbaRFNEri4YKbzYmqP",
+        "f375efef0cc2782d02c229bd4dafc2e4c73490535ebf18a9f4a910499a473002",
         {
             "chain": "main",
             "isCompressed": false,
@@ -57,8 +57,8 @@
         }
     ],
     [
-        "GzWWg8cuPmoLeZVVj1dbSVrMhWK3kQd89xsHarE8y8rrGo4tgcLg",
-        "1a72d3d8d1435d500b9f4d4ba484c30fc3ec720a0da5055dc02995a485f703cc",
+        "GzgjQJZFigkZx4dpCdhUCaUmxwkqVrgjAkhPRmpW78v4aZUkXi22",
+        "1fb4afd8a289d8b99dce1e94b0e0cc7581e43cf5d248408b6baa6e50d2e00d59",
         {
             "chain": "main",
             "isCompressed": true,
@@ -66,8 +66,8 @@
         }
     ],
     [
-        "2YXsbNYw5iHBTcKjhi4H3YBseEgfrcQEBidZsFPinMEuDspuXmt",
-        "0f0d41dc312549829b2ef82aed95c33e13c00ea7ff2b3af71916dc3904025505",
+        "2YuSKAy7dkf6R5AEQZBX7UAWXbopozEV2ZabmuQ6vaGHJEL1jV3",
+        "40040d35cbfc9cede681cce4b8501fce24a99cdf05e1f5b53461469c2f084614",
         {
             "chain": "test",
             "isCompressed": false,
@@ -75,8 +75,8 @@
         }
     ],
     [
-        "7qHg3EWD1ru1A8YDthMVFv7iANjsS1Tx99t4A8u24Zezee8XoWei",
-        "302fb2496114e46ff03037a46718b8c93edf749920f7f46d33055f0e3e2f86f7",
+        "7tp1fd4RfqP5CEwcMt1K4u4xnTgdRL1LTRszTeMvGSkAr647w1aa",
+        "994e442abef57b253dea05f4d1ea447397be163deb5c316a9995f06d2c4f2fd2",
         {
             "chain": "test",
             "isCompressed": true,
@@ -84,8 +84,8 @@
         }
     ],
     [
-        "2ZQ9kmGR1HfgkFsUzg9QP5HEiajea5ggD9ZQmQLFRKEkiEmwXrg",
-        "813732e8c4362c7c4b70ad80563a656b9806e6ed44a5e3cdcda249df136a4e76",
+        "2aGa75qpwQegc3UcEEZb5x5ivYXczd3UM5vxc5qacRU3VktEuzh",
+        "f3b334901663e493496b9b00761dba0ed41c4dbdecbb15cdf1e165c834b64d30",
         {
             "chain": "regtest",
             "isCompressed": false,
@@ -93,8 +93,8 @@
         }
     ],
     [
-        "7rGU3JSR9HuGBkvZn81GfwuvYu9XR5FdvL2Uk4s5LuxyYSLTvuy5",
-        "4d6721099e0fd486730fdc46ef15c23c9128654da19edc3ed8442016280661e3",
+        "7toaqmaJ1U2CEM2a3JY5mibKUR5jrefQYRUFmCZ2GneRULvDtDvV",
+        "9915e5e03e67a34039d962258e198deb05628393d1e3ee38203cccec763bc4ea",
         {
             "chain": "regtest",
             "isCompressed": true,
@@ -102,8 +102,8 @@
         }
     ],
     [
-        "pw1qcgry75460nv5mdfcgevzqfe5myfhu0wk30tr73",
-        "0014c2064f52ba7cd94db5384658202734d9137e3dd6",
+        "pw1qxxvu7p64zutwptc5yexhjx5rjh92z2zxrvlg7d",
+        "00143199cf07551716e0af14264d791a8395caa12846",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -111,8 +111,8 @@
         }
     ],
     [
-        "pw1qd8dlw6mwfl9nmqyh22mglpz37meacwapc0hljqxp4920ch3lkc4srav0dp",
-        "002069dbf76b6e4fcb3d809752b68f8451f6f3dc3ba1c3eff900c1a954fc5e3fb62b",
+        "pw1qxqqzwj8e0q8amw6v92l3edcr34lk2066dxtvwv2957ccv5ty2x2sfw66ht",
+        "002030002748f9780fddbb4c2abf1cb7038d7f653f5a6996c73145a7b18651645195",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -120,8 +120,8 @@
         }
     ],
     [
-        "pw1pmweswj67uw",
-        "5102dbb3",
+        "pw1pw5rqsuphsa",
+        "51027506",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -129,8 +129,8 @@
         }
     ],
     [
-        "tgw1qqwl46dyeg65rnu6x6h4dxlpskda7gvvt3z0dwt",
-        "001403bf5d349946a839f346d5ead37c30b37be4318b",
+        "tgstw1q93pssv3jsvc6m2t0f3juxht54wpdh728spjg9w",
+        "00142c430832328331ada96f4c65c35d74ab82dbf947",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -138,8 +138,8 @@
         }
     ],
     [
-        "tgw1q50sqppj9fgdppskywmvdg5avu4ph5jdk3z27lpnws9jjxp5wurtqptpf8f",
-        "0020a3e00086454a1a10c2c476d8d453ace5437a49b68895ef866e816523068ee0d6",
+        "tgstw1qgn4g06mtjrujkmnxj97uvtjsv2a0w923gfr68vaa568suya37res2k7jv8",
+        "002044ea87eb6b90f92b6e66917dc62e5062baf715514247a3b3bda68f0e13b1f0f3",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -147,8 +147,8 @@
         }
     ],
     [
-        "tgw1zcq3ssg88p00re9ukrmg8uh3ducdzs4mu",
-        "5210c0230820e70bde3c97961ed07e5e2de6",
+        "tgstw1zpne659dwf7ftrwqlmygyucvcuu5mmw0a",
+        "52100cf3aa15ae4f92b1b81fd9104e6198e7",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -156,8 +156,8 @@
         }
     ],
     [
-        "rtpw1qs2ah4vy9gd6ce0s62esx0ngcz7zykejzkmkld9",
-        "001482bb7ab08543758cbe1a566067cd1817844b6642",
+        "rtpw1qj3p2q8lctzewt5czgje3l40syyfwr5dv2xyche",
+        "00149442a01ff858b2e5d30244b31fd5f02112e1d1ac",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -165,8 +165,8 @@
         }
     ],
     [
-        "rtpw1qrya2mrglegaycw0fnkhgr58jvv3ccfmkets6vz67y3xvlql7nltszlc8wz",
-        "0020193aad8d1fca3a4c39e99dae81d0f263238c2776cae1a60b5e244ccf83fe9fd7",
+        "rtpw1qyhcr3grsvxugs3ckwrtdxfx8l7xa348pqhl7lae2cmcahsla25vsa0v2ps",
+        "002025f038a07061b888471670d6d324c7ff8dd8d4e105ffeff72ac6f1dbc3fd5519",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -174,8 +174,8 @@
         }
     ],
     [
-        "rtpw1shc8fqcvr49mkw4mcqmcnvxwzx4235292nes90q86tp5pxtqskdsx5yqhxfzarwnpcrnn6u",
-        "6028be0e906183a97767577806f13619c235551a28aa9e605780fa5868132c10b3606a10173245d1ba61",
+        "rtpw1skazesexrrl02rxr27k89tq48f37ez7a89ten2vwnlhwwgvpv0uheqen9f37qgpr0sl7k56",
+        "6028b7459864c31fdea1986af58e5582a74c7d917ba72af33531d3fddce4302c7f2f9066654c7c04046f",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -183,56 +183,56 @@
         }
     ],
     [
-        "PrmutARWekExE4zXFUULBcU9o4KxfeRH4X",
-        "76a914cebd1c0dee55356a7ce90ded66faa99ab9ae4d0a88ac",
+        "PrXtbbFmUtmRgGac3mb23FJG3XJmtXZzyR",
+        "76a914cc16367dbbd010285f785e9ca8e2a8ca216c006b88ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "R9pJixvmzxzLRUKtM5fJFzzkmEALnLQ1XY",
-        "a91405e2713d6f11779a32b4f2f27b04d645c515eae087",
+        "RTCovFRZZpQ3KcsYC42M2PrDL6kYPAgZtA",
+        "a914c49e1a2af18a0e40dc780e7033a43524e632869487",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "XDL8Zaq86AMYNrDJcv823qHzEdL7YCAa5k",
-        "76a91415ba96b5a022836a51a5205ab7ce8b76dca39a7c88ac",
+        "XYfs4U4EtoBgJnU1HWPXuC9xqqHWGVKy1m",
+        "76a914e9e05b7f08e29df37cee58de2a95139418119d9188ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "xKmehoM3k1QSKwtrXxoqJSSVdQGcZYF63d",
-        "a9147dc54a38082da886ab905b74183449221ea02dea87",
+        "xQqUuYxh2aHjRtGGLcq9Uix9ZNNVhgVnEX",
+        "a914b557677c745d07c6557ffb2658ba2f18e4b5934f87",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "pdaxxvP4yPvvaNB2qX8HzcfWeujkLKpMsG",
-        "76a9145f77dba9027626600d1b92218197226b862c2d7188ac",
+        "pVXx8cR1ELQikY6NHXeh7GjopzV4C63SXh",
+        "76a9140724e899fae140343dc05e3d997584814403274088ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "rBvSqag4oz3aMHA9vaKcionWgQSnSMgEjN",
-        "a9143e62597567feb83a6dfff706b3b70216f6e4d42e87",
+        "rJYANHBU7ixt2Ca4t4wbEVrvKTH3B9Pqcc",
+        "a91486f4546807e0d4c124addb0e0e137430475c53d287",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "4e96i4usHxvDZrCoWFDrwB6o4xQfAqALiAXN42cdpCjm4LzuSfH",
-        "9e43b9c376fd1ace3ab085e2401966c14fabec4a23ba791ec904c0f5e981a423",
+        "4dng8ex8r6zJ6SXGzXbfDaT9oXDnpcadM7DE3GqTnr2BEA2QdgT",
+        "6fe3d619d2d083cb46ef9c55dee30384ecfaeb3ac4b0098336948492440005a5",
         {
             "chain": "main",
             "isCompressed": false,
@@ -240,8 +240,8 @@
         }
     ],
     [
-        "H4sujMrMg6dFj3rh4AXSLpfcM3QqGdgH8fb6VFTh2hdNpFHzw5rZ",
-        "9cce4a53442bf90a829c4c6b4c39e43264677ca520c24463dde01450ea345d8f",
+        "H3S6ZgbZF3bGUKvbHP2dfnWW1F7aaip1YPuQCfy6rZoYTABAnyzK",
+        "71b06a951e0780567968fa0680933fabe7ba20021d9adeb49dafe84d3f8fe4a5",
         {
             "chain": "main",
             "isCompressed": true,
@@ -249,8 +249,8 @@
         }
     ],
     [
-        "2YU2GxyA7wLJBYX5LBcuw298NZS19gyxy26Rc7vSUx5UojxxkG4",
-        "064f28702acf2fbb26791db6e58a78087dda7918d632b03c5176f8cdb3ecd574",
+        "2ZhyHTMyfguEfaucJwNtM7SjYjLetMKDBKSNGfdMytKQKD7Cjbj",
+        "a9ad49876a4c3b44acb0f54165ef508cd08ba677a1d31bd4104fbbd3b9be6ea9",
         {
             "chain": "test",
             "isCompressed": false,
@@ -258,8 +258,8 @@
         }
     ],
     [
-        "7tn3cJAdQTYPp29tHoDR2xPcYvr2WVDGcQSguZUFzWPYjQafAmH9",
-        "984b48fe78981fcf8c4bec680f8f412fe9e42134daa60377831efd6df6256b89",
+        "7rJ1JwrjB85A17grXTEJALz8S2VshEFUeb36BujRQ4aADChwQ2By",
+        "4e31d3b18748029c06839b40f2c341eca964f71f4f6b94f276844e7a0509f851",
         {
             "chain": "test",
             "isCompressed": true,
@@ -267,8 +267,8 @@
         }
     ],
     [
-        "2aAHPpPLACxFspMhPkrNB5pHyiD9VXC1fHx9rsTCUwrE8Agk2n3",
-        "e56c0bbffb3b74635fb2d702e29d5002d716acb512cba063f1c7b3f61d86b270",
+        "2YfPJxxsz7a4d2TDqgZNiHASVEcWaA9FXJdTYs4cwfJjmjTvnEA",
+        "201c0a0abcc977506f2ba45ee50bc9b5d80502720d1ab33c4e7583e000eded91",
         {
             "chain": "regtest",
             "isCompressed": false,
@@ -276,8 +276,8 @@
         }
     ],
     [
-        "7quHTk52pwYPSQGPDyKFzoede3BKocQBQkEbLfVZ4a9sBb8BCtAu",
-        "42817db708182de7a4b7d8a042e89e200e69d1e9ebcd37e5e45338373d37edf1",
+        "7pdKBfYyTXDGjBRYqqJUTggnoajYEpXePmKoeBQUDtaHYWV8Rt7i",
+        "1c73e44f6f21948ae945330ab77b4bb5dc0538775933fa37d8e00e3fa535347b",
         {
             "chain": "regtest",
             "isCompressed": true,
@@ -285,8 +285,8 @@
         }
     ],
     [
-        "pw1q4tw43a9seysxua8vtzc96nnjcnvsa0haf3fw8p",
-        "0014aadd58f4b0c9206e74ec58b05d4e72c4d90ebefd",
+        "pw1qfg2qte8yrxne9jtyaxkhmhchrd5wjt4u2skx8x",
+        "00144a1405e4e419a792c964e9ad7ddf171b68e92ebc",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -294,8 +294,8 @@
         }
     ],
     [
-        "pw1qykx2fzut7zl0u53mqdy3d65hj2ueg5vsaynmp98q50w5hflt4rnqmj98n0",
-        "0020258ca48b8bf0befe523b034916ea9792b9945190e927b094e0a3dd4ba7eba8e6",
+        "pw1qwcwhxkf2gcn6teneamcmtqeryp90wl8fkkf3uwl2p5ssgrka36lq90dtr9",
+        "0020761d73592a4627a5e679eef1b58323204af77ce9b5931e3bea0d21040edd8ebe",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -303,8 +303,8 @@
         }
     ],
     [
-        "pw1pmv7swhvdl9",
-        "5102db3d",
+        "pw1p62zsrn4uts",
+        "5102d285",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -312,8 +312,8 @@
         }
     ],
     [
-        "tgw1qqgewwgptm422f27spcgk8n9yzvff649w38h6r2",
-        "00140232e7202bdd54a4abd00e1163cca413129d54ae",
+        "tgstw1q54hnmuyc5ntpe5xt0gcs0pygln3zt6hpfnk7p0",
+        "0014a56f3df098a4d61cd0cb7a31078488fce225eae1",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -321,8 +321,8 @@
         }
     ],
     [
-        "tgw1qml8l5x2a5nze736rf5waskmkmnaptqq5l8wevem3xgs9lru078fswcc56h",
-        "0020dfcffa195da4c59f47434d1dd85b76dcfa158014f9dd96677132205f8f8ff1d3",
+        "tgstw1qn223xdhurgrtxvngyyg9te5nrlnwjfz230pe0wtkya7va5xpc5gqh0ddy7",
+        "00209a951336fc1a06b33268211055e6931fe6e9244a8bc397b976277cced0c1c510",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -330,8 +330,8 @@
         }
     ],
     [
-        "tgw1ze6w84pq2f05jzu3qfjuhjzx46vfrdwzh",
-        "5210ce9c7a840a4be92172204cb97908d5d3",
+        "tgstw1z7s3k9x73psz579msep6y690uccas4rl2",
+        "5210f423629bd10c054f1770c8744d15fcc6",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -339,8 +339,8 @@
         }
     ],
     [
-        "rtpw1qgk4aakvwp2k6kuk25j3k4mm4y3gg2vzxwq37pp",
-        "001445abded98e0aadab72caa4a36aef752450853046",
+        "rtpw1qxmg0n0zk2dafp6zdeypvwtjfutl8wurl0k9nmg",
+        "001436d0f9bc56537a90e84dc902c72e49e2fe77707f",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -348,8 +348,8 @@
         }
     ],
     [
-        "rtpw1q74pr6t6cadd8k23hknjy3e8ax7sjzhm7mw5pqpr3clgzdffry7kspys7re",
-        "0020f5423d2f58eb5a7b2a37b4e448e4fd37a1215f7edba8100471c7d026a52327ad",
+        "rtpw1qjh5dcs32ddf695kfjlyhxach4cz0tgalaxm9qenlvj8m6e4668rqpammhh",
+        "002095e8dc422a6b53a2d2c997c9737717ae04f5a3bfe9b650667f648fbd66bad1c6",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -357,8 +357,8 @@
         }
     ],
     [
-        "rtpw1sj92t48u228z8mwtdjmmjuhdmdvn300pd7n87rq8dy2zp55a4yc34ja34ekcxzvlqqs0ud3",
-        "60289154ba9f8a51c47db96d96f72e5dbb6b2717bc2df4cfe180ed22841a53b52623597635cdb06133e0",
+        "rtpw1sx9msdzhffrgcjjw7ujz7lvw65w4dvjwsj2rk7heny7kuhvz472u5kcghmpe9wmpyxaejqx",
+        "60283177068ae948d18949dee485efb1daa3aad649d092876f5f3327adcbb055f2b94b6117d872576c24",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -366,56 +366,56 @@
         }
     ],
     [
-        "PiZ46mtZ4Yt84o5gmMTfBsXZccoXGXcYwb",
-        "76a914748d8e2dd8f3c8cfda87d5189b9bfed478408e6288ac",
+        "PqNuovT1N6beR8HDz34XQrWgR7gWECjtE2",
+        "76a914bf6b5b0b9559052fd0dab75e81e01b26dede4f9088ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "RPVUjkbaNDkC9yL7jxjfncCMqGdVHP7F75",
-        "a9149be4a8b140bb67a098bc997d147e0dd5a0d5e8c887",
+        "RDM6BKNvKSLPcfNUTSkks26qjVd4AZ2t7Y",
+        "a9142c9d3def5b3526088d061710517ab240438abf2f87",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "XJf33TJVJeLcwpngauvzvT9E3o2QuaKYaV",
-        "76a91450268372ef78c00e0f8df6d877f2c2be2620e39e88ac",
+        "XDfd8cmHXP7P8rSu2ApA22zP7GoxhdkUm9",
+        "76a914196a5733cd3d623b6886df03e2b6a9948e965e9d88ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "xJX6HRBYVhpREZXqhY9SnvKfTQX6Jq73m5",
-        "a914700c470a0a29b97490a0197034dc02fd5555883387",
+        "xBnptCfxPYiCY63BQHYzuP2kJmA86FpZ3w",
+        "a914263d326815113a1e94395d95da906f23b926ab0b87",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "pbKtXqKeWJN3mWwo9QgFsY9ttNh4zrvcfK",
-        "76a91446adaabdaa4c9a33df6ce7a7ea2db8ce468d2f2088ac",
+        "ppV6Doq6ET8RYBJou96uHVFK3qRupzTcFH",
+        "76a914d704cdafd421b027228c0773dade6aea853af3e488ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "rJxNz13NTZURm9cjSYzt7qJsDNzSe4UT5S",
-        "a9148b88d81123fde674f0dc0a58b48c954a01e0c13687",
+        "r9mkCAEJtBUhnrycbLXHvw9eAhQuUV1Guk",
+        "a91426ccd75e5e733392f2ad1b4054b2c6ceeb0a8ae187",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "4eKj7Rhs3bDZ1hmz929mGjEywgbnWLHMfrGZUxrPkkH1ucu8wT3",
-        "b665595d62c2401ef24acb3e46fecfe067f3e85de884b1c5d1e7c17fd46740e6",
+        "4e3mpJEDHcWwz4mM1Gj2gFa5xEWK5JxHzfcaxVZXjJrC2S5UbGD",
+        "922bfc84dd857aa0964750157e31f61f4c58f84c8eeb27cf823738332e75c54a",
         {
             "chain": "main",
             "isCompressed": false,
@@ -423,8 +423,8 @@
         }
     ],
     [
-        "H3RsUzWmoFijecBWQuNfPzhC1NdmMSkbJgqTuge5J6EejobvNRep",
-        "7192b6efe733cefc4847e9aa4ecec2cef8f2bc021eb94b14250ce4f523ea81b3",
+        "H1rjeyJX5CF1PC8RVUxEa9xWc1mnWUXkfFaein7ALPZYCcRNFpmr",
+        "42b0987a34b261ad54b3b7a85457702b84185a7ee84f7c5682ecb3b346fd3458",
         {
             "chain": "main",
             "isCompressed": true,


### PR DESCRIPTION
As  we discussed in discord there are some errors with the key manager:

```
2020-06-03T16:27:20Z [default wallet] External scriptPubKey Manager for output type 0 does not exist
2020-06-03T16:27:20Z [default wallet] External scriptPubKey Manager for output type 1 does not exist
2020-06-03T16:27:20Z [default wallet] External scriptPubKey Manager for output type 2 does not exist
```
However this errors are there without this changes too, i am not 100% sure but it seems the address prefix changes is not affecting overall functionality, at least i can see keys generated fine with:

```
$ ./src/ghost-cli -testnet getnewaddress "" true
tgsth1g5rn9eetjze8sqr7ssv7808q0y6xamn622tc2u
$
```

I also made the changes in the python as i found the `tgw` prefix there however i am not sure if some of the other parameters in the templates should be modified too.