### PR TITLE
Change prefixes again

### DIFF
--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -70,9 +70,9 @@ bech32_templates = [
   ('pw',    0, 20, (False, 'main',    None, True), p2wpkh_prefix),
   ('pw',    0, 32, (False, 'main',    None, True), p2wsh_prefix),
   ('pw',    1,  2, (False, 'main',    None, True), (OP_1, 2)),
-  ('tgstw', 0, 20, (False, 'test',    None, True), p2wpkh_prefix),
-  ('tgstw', 0, 32, (False, 'test',    None, True), p2wsh_prefix),
-  ('tgstw', 2, 16, (False, 'test',    None, True), (OP_2, 16)),
+  ('tw',    0, 20, (False, 'test',    None, True), p2wpkh_prefix),
+  ('tw',    0, 32, (False, 'test',    None, True), p2wsh_prefix),
+  ('tw',    2, 16, (False, 'test',    None, True), (OP_2, 16)),
   ('rtpw',  0, 20, (False, 'regtest', None, True), p2wpkh_prefix),
   ('rtpw',  0, 32, (False, 'regtest', None, True), p2wsh_prefix),
   ('rtpw', 16, 40, (False, 'regtest', None, True), (OP_16, 40))
@@ -81,13 +81,13 @@ bech32_templates = [
 bech32_ng_templates = [
   # hrp, version, witprog_size, invalid_bech32, invalid_checksum, invalid_char
   ('tc',    0, 20, False, False, False),
-  ('tgstw',   17, 32, False, False, False),
+  ('tw',   17, 32, False, False, False),
   ('rtpw',  3,  1, False, False, False),
   ('pw',   15, 41, False, False, False),
-  ('tgstw',    0, 16, False, False, False),
+  ('tw',    0, 16, False, False, False),
   ('rtpw',  0, 32, True,  False, False),
   ('pw',    0, 16, True,  False, False),
-  ('tgstw',    0, 32, False, True,  False),
+  ('tw',    0, 32, False, True,  False),
   ('rtpw',  0, 20, False, False, True)
 ]
 
@@ -108,7 +108,7 @@ def is_valid(v):
 
 def is_valid_bech32(v):
     '''Check vector v for bech32 validity'''
-    for hrp in ['pw', 'tgstw', 'rtpw']:
+    for hrp in ['pw', 'tw', 'rtpw']:
         if decode(hrp, v) != (None, None):
             return True
     return False

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -677,17 +677,17 @@ public:
 
         {
             std::map<int, std::string> bech32PrefixesMap{
-                {PUBKEY_ADDRESS, "tgsth"},
-                {SCRIPT_ADDRESS,"tgstr"},
-                {PUBKEY_ADDRESS_256,"tgstl"},
-                {SCRIPT_ADDRESS_256,"tgstj"},
-                {SECRET_KEY,"tgstx"},
-                {EXT_PUBLIC_KEY,"tgstep"},
-                {EXT_SECRET_KEY,"tgstex"},
-                {STEALTH_ADDRESS,"tgsts"},
-                {EXT_KEY_HASH,"tgstek"},
-                {EXT_ACC_HASH,"tgstea"},
-                {STAKE_ONLY_PKADDR,"tgstcs"},
+                {PUBKEY_ADDRESS, "tghost"},
+                {SCRIPT_ADDRESS,"tw"},
+                {PUBKEY_ADDRESS_256,"tl"},
+                {SCRIPT_ADDRESS_256,"tj"},
+                {SECRET_KEY,"ttx"},
+                {EXT_PUBLIC_KEY,"tep"},
+                {EXT_SECRET_KEY,"tex"},
+                {STEALTH_ADDRESS,"ts"},
+                {EXT_KEY_HASH,"tek"},
+                {EXT_ACC_HASH,"tea"},
+                {STAKE_ONLY_PKADDR,"tcs"},
             };
 
             for(auto&& p: bech32PrefixesMap)
@@ -696,7 +696,7 @@ public:
             }
         }
 
-        bech32_hrp = "tgstw";
+        bech32_hrp = "tw";
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
@@ -828,7 +828,7 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY_BTC] = {0x04, 0x35, 0x87, 0xCF}; // tpub
         base58Prefixes[EXT_SECRET_KEY_BTC] = {0x04, 0x35, 0x83, 0x94}; // tprv
 
-        bech32Prefixes[PUBKEY_ADDRESS].assign       ("tph",(const char*)"tph"+3);
+        bech32Prefixes[PUBKEY_ADDRESS].assign       ("rghost",(const char*)"rghost"+6);
         bech32Prefixes[SCRIPT_ADDRESS].assign       ("tpr",(const char*)"tpr"+3);
         bech32Prefixes[PUBKEY_ADDRESS_256].assign   ("tpl",(const char*)"tpl"+3);
         bech32Prefixes[SCRIPT_ADDRESS_256].assign   ("tpj",(const char*)"tpj"+3);

--- a/src/test/data/key_io_invalid.json
+++ b/src/test/data/key_io_invalid.json
@@ -6,147 +6,147 @@
         "x"
     ],
     [
-        "4d8zQHRGBsEM5oDM9PxWS6CXDd5cThouDhygDwF4AM3CJt1Q2gCp"
+        "TnKdVh58zacmZkPJvDLBkg2PiC6SjW3TkU8JTc37auv8ufgej8jxAvfXx5s8snsC5TkfrrmEHBh2"
     ],
     [
-        "2zz4A6RSmJJsGXutw33cyamBgWTniRfnAHgHV86wJA1Zk9Sm74C"
+        "fkWyKAHe1BYTwhcPRShyAQuuGT1u2kJ7AYrSQF28f82KUN4EzUKwwqkwkhD3nVH6muCFM6Eh5SV"
     ],
     [
-        "HawnNccY4eAftYiXHivq4G5PrgrDBjV8jA8FkdmP5Mz339g3HEAZA686wPMVCFv6B3L45V4dQsv"
+        "7uY1911cjBhUBU47FrmsjHfgR5TpyKfLmEw46oQgtmB7zaVsj7nM"
     ],
     [
-        "tc1qffxp8qa79nzajxlu6alrj7nv4ks645ly4ejk4m"
+        "2GU5w1KFnmdqYAmE9zAYEGLc1ti8wj4AenoUdgfGWKyyw3vcnJwj3VMGgtY8UujXT7MCng1UfAGvZ"
     ],
     [
-        "tgstw137swvxnn988c55rr4afcf498x79w0ty99l5s3au0f425w9mtmxa7s2h499c"
+        "TC1QUWAKVFSHPPRJJ35E0M420CMYCP2SEDFYZ4F38S"
     ],
     [
-        "rtpw1r8qmfyxu8"
+        "tw13twtg4xddkx9ukwldeyyy5335lv6d06eqw4k94h0gv50u9uadvsxsj7wnsz"
     ],
     [
-        "pw10xcfxkrtrg7l4dle4pwp4uc3c3nsp3rwdmcaqc9fjde5rhatkyutr86ej0dfe2jmzwqzvqtwq"
+        "rtpw1rrypvnnk9"
     ],
     [
-        "tgstw1q7hcvetxycxeeg7edjpykyyltcgvzj0nm"
+        "pw10mtj3xahmvqc44zsejhs2tx3wc3nwcsj2l8awz64glynnrdlv7ermqyvjk6pd3f545u5zc3l9"
     ],
     [
-        "rtpw1qjvpcv4tpvfehcwjhq9wx6e543tm6ezm049xazyzcsm0chzhvqm83qvnu72"
+        "tw1qdnr6hazvv6hw035w492j82qzausaft0s"
     ],
     [
-        "PW1Q0P8J9ZJ7Y689UEMTGGXSH522RVQGFXX03"
+        "rtpw1qx0m2lfnh0qd6mnuys0ml8prfjs027ktwssjc505x3ygyeq60d7k3ascv42"
     ],
     [
-        "tgstw1qvzv32zlernh3a59p985l9w34zl5aze9eanhavpt5dxy4h0dzpdjshr76cv"
+        "pw1qy62v99jasmupksv83rdsryhsluqas6fcp"
     ],
     [
-        "rtpw1q5s4ugpzg7mxjr5S24Uf6amg6jydn9um3kq9y94"
+        "tw1qje5c5aa4etty4ncz5stmljtlhsjj60hg9c4cl8ur935zy6mjwhqsj9cf28"
     ],
     [
-        "TuBhrUwYhT1HSw3vtAsbftr7sH6FzAT9M4wea9YLxh7v38nhhP8CdqNUBoTX3ucZdjFyQYb9YgN"
+        "rtpw1qy3rgmepurrem0h64c8etqr04FXq48wlxf5e7ck"
     ],
     [
-        "pXbtXoiSksnPAXmuiUrADqxQLE6pVHAYt8z"
+        "jtLAUbi7E3yfMr18c6yWMeCymHkuVMq3eh"
     ],
     [
-        "H6XoFSi3p5NdnZ7mwKSLgB2CeK5rvTRt7a8nB5FPvpEuDxXXrXyH"
+        "WxvPL2jMgKG62uQcGPstoqu8zm4Z5HggVe"
     ],
     [
-        "HXMU6xHphjt5s3E7Xsqy6orFeeXntRDxWVzjbmXRc8WkVawpSAYVxTukTD6Mvp2WuN4GCvjJRYn"
+        "2FCZhqi7YUxd7rZHjCohDDF2DDt8mz6XS7eVhNxcZFLwdaLygto4qE4ZZv7fnAdMJnAiGcVyVJ9L"
     ],
     [
-        "tc1qqpsrapmdvxux2pntv4l26f4efanm545mgslwpy"
+        "un9ctTwnG2p3paiUMeKdZkxxfp8fvjpuv3"
     ],
     [
-        "tgstw1308a8aramuscsyvt84kk5gwq2zd3t52fmucujtqh83amjjdf5fylq7fs0cz"
+        "CYYnAhCUrspV4yKCTQxsU8GkdroCrikm759rAnAhdhhNUWiJBT8m"
+    ],
+    [
+        "PggmDQu9hFKo9Q9hcLcTPi9Kz3fLdMPVuKE9UKuPjnznmnzVsgtTk4gwkCmh7hvNdQ2QWkh7r86"
+    ],
+    [
+        "tc19jm4rn"
+    ],
+    [
+        "tw13vr7f35ct0ceu84whyrjd840n9dzudjltxmw2hx8z0c6sr92u68vqcaampf"
+    ],
+    [
+        "rtpw1rrc9napj3"
+    ],
+    [
+        "pw10c662h6t7sxw9x654f7nale94fdkgdmxr2umw04le2atmpqpwxd0pk69jgqkmf27k7sftx052"
+    ],
+    [
+        "tw1qk0m0yn7u0tpw3uqmz69xhudq95jesfcp"
     ],
     [
         "rtpw1rqumh0"
     ],
     [
-        "pw10q9dp5lznv468l0dewqgcne6k3egkc747pnc2nhug9re70xzg0gemjzrvwu68ny800y5q44gh"
+        "pw1qd3e2c03k7uaajgr99l54d3j65sqpqzp8d"
     ],
     [
-        "tgstw1qxwyhhq05lf5p7pxe38ey9x7wac7ev763"
+        "tw1qec0z3558vh06ztxusre0jvjhnpe2y8ml575y4smzkyyzy956cd0qmwvshu"
     ],
     [
-        "rtpw1rqumh0"
+        "rtpw1q9uxy393y5ucurH0ANrej04zftnv55c4jdnwk76"
     ],
     [
-        "pw1qu725ev3wr9yclegjwupjsq5zsuq4fwh4g"
+        "AJvULoRHpY5iPPpf5CHHzTArazeMUzdGRV"
     ],
     [
-        "tgstw1uzn7qa"
+        "X3xBK4gvspiaKvwRLkxoB5NET6z72jVRiyEAUPyQxoZxeSukT6Uv"
     ],
     [
-        "rtpw1qdl2tysmaljk4xv7hyazzf28v3628P3Lk70x0e7"
+        "G8Svo39y8HAEnEprRboXEm8wTDXaEP6MWD1NTE1q79nKDpeTK3hLPfjc2Y8RnkYSYAZC11o9Kij"
     ],
     [
-        "255rkZa87CViXDJDMaxUjYQdDzWh9DSKL76"
+        "2GLXebtEsMk3z3jdE5HrZ7ShhJ4EkHjgko48XdfeKQpeJgVvfFeVvLgw4zcjHY8oJEkVf3mveDk5v"
     ],
     [
-        "wMz5RRHaMA8cMZZBLkYdeaYGW8NsBSbpBe"
+        "tc1qkyc62gyh7usrr46z4kwk9ajqc34rm3zj79mm5t"
     ],
     [
-        "txhDzv1C6wtNEN4BukmZY9YC6T8kLaGuv3"
+        "tw13gawkvj427wwg7e6hra4vm9q43t677e6dhklcv8m7pv7a733jgnss9fnz20"
     ],
     [
-        "3wF7NAJBjknkc8ndPMKtA74Nqc1ZVgLBh4UZAZJgbTNRXBRcsHtwKs3a9n9T7Ss3aBY4aXn9io1ER"
+        "RTPW1R55KEEP0L"
     ],
     [
-        "HRZvQ7o1A2DmcP2RFHENoiW6ji7unPMGmV5Dz3pPwsUYCjXLe4Eakt6Udnk7GHUMZv1D4BqVhAD"
+        "PW1046MR8C2UCY8VGD9Y9PJNAM7LZZ4L7K493FDGDP22Y6MXSPHJCUD6FVGN27ZHYV7L8CXJ25V8"
     ],
     [
-        "tc1q4mvvrjnhsnw86ex7dql4dcqupl28wjghqcsz98"
+        "tw1qvhdxukk7gr070pfnv9psgsq4vv3udyz9"
     ],
     [
-        "tgstw13vvt9juazydltl0wjdgr599v8zhf9uea4pc7w4g0rl3gt76ryr33q2tn5nw"
+        "rtpw1qxgtavked76sh4ctewx9l7jek2w54k75nzq74890vk4gquj4dadg3f5sev8"
     ],
     [
-        "rtpw1r7c62zezd"
+        "pw1q9khukpjgpyngkvty6xwqggc8hsqq3pfht"
     ],
     [
-        "PW106GGF89ZRYNQ8WAE83KHEJFA3LRWNV92MMQ048Q9TW8L5MX6RHDTFWCFD8Z9RJURVFV0QJ0AJ"
+        "tw1q0p0f2a6qkdpgvw0sgapx6lvlqn7ncw0jjgcrw6e6drd8q2z5d3ps9chrru"
     ],
     [
-        "tgstw1qrg9xhsg5q25jvv7txnvm24c0mvh3q787"
+        "rtpw1qrrxw742q6p5p4gMAGSy7aaykzypyga5snyasfz"
     ],
     [
-        "rtpw1qpypgd9rfcuhnkphr89z3xehzmkyp46fvaae6qphy3m6shjy5fzj32s844v"
+        "2ii9P3uauLkbzbJHXjuKWWpLvxtjUkTYTLU"
     ],
     [
-        "pw1qhavrl7u06udv59p9h79tv9z0sqqs5g93u"
+        "7ewKkdDP6jjLnCR8QCSHS7fi9GoWNLkGvPxpgoBaA71zuQCpAAH"
     ],
     [
-        "tgstw1q5kyg29e5ku2ztxs3tnstur02wr92tegzf0wlaujqar20qennejzq45cq6g"
+        "3wQms4kU2KtevwZPW1DtPvcWSwNnDYSARU6sbtSTgU59PJFmqoDWTXHQZKDt6fv6H7poLbm7MiDub"
     ],
     [
-        "rtpw1q00gDKSW93h9gxgyzt6lyyex53kfs0u8el8akx0"
+        "2GYkNVvcCyVTW1PcQDz6iQriKUCZ8B2HU4wLMqcMN6pruxBde9jX9Vc2Xb9fYCHG9mNDEwWZCYYqa"
     ],
     [
-        "TuEaDgxm4ku93VnDgisJeyLs3cg5Bvyt6ns6p4NsNbK6N3SWRwc7ckZYxrw1nrEEJMRkhrTuDSs"
+        "4Evd1Nxz4SCVWk3Sz8M27fCeiA8XfSvP1qNjiPUJJsFVqm9c4Tc"
     ],
     [
-        "SgckC2a5EAuHH7jhEX5b4NfHFQkmgQnRHN"
+        "tc1q4mlcfkk496hyle3qmmhdjpgcalckx7jpk5gt75"
     ],
     [
-        "2CxeMAdWDTeTM6XQG1hk1JLQLtZcZNdc1fs5zLA9KnHRzyfNV2LGqpSXFpbbw3AWdGGsTqpkuPvTj"
-    ],
-    [
-        "7tX4QCSErBTeVnidqR7ChJZuRotiL2XpZcbD2W6UmHCq9qjVjLRB"
-    ],
-    [
-        "jbWUpPecs8pzutMd6MHHzi5J6vdRnAb5x2Y81X6SX9DiTNX4oppoSzA3aEV5z9DinJm4YQWf4YK"
-    ],
-    [
-        "7ugrUXn5wQEchBTtv8tWw6VwrKfMZfhjWwxy3zffx6M2THycQjnuJ"
-    ],
-    [
-        "tc1q0mlfwz9euy2k9zq32zms2dten46r7zhjdzptef"
-    ],
-    [
-        "tgstw1uzf7qa"
-    ],
-    [
-        "RTPW1RWCULY8KK"
+        "tw13tj99ygt9gcfe84n4m0cstec9amtxfjrw4v97jlrr89ldz0wz4d6qrprj4s"
     ]
 ]

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -1,55 +1,55 @@
 [
     [
-        "PYUQDGfujFrDGJYgayss3h9e9tecEyRXtw",
-        "76a91405fb01a32a63925b1c01f149651e15b8a754a96788ac",
+        "PcrDXy23R4Am9qT5LFznvTTubQ1ggjmNXC",
+        "76a91435fbbf5769f8ac5f47eb550f01486c10b23fa08f88ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "REWV2SezYgGCd9ZYveJcv2XvpX551Ne3dm",
-        "a914395c2ede63f9fcfd0f56dc3ec59defe331c41b5f87",
+        "RHESQJ1wD4W6FB4A6WgGUCEo3u6sPbFMRo",
+        "a914573bb71b2bfa15fa21d6bff218738d3b293c566687",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "XUWEsA4scTeEcLretXzGWBdQXQLdKQU73i",
-        "76a914bc2de584405fc30a24530282195d1130463e017088ac",
+        "XY1hBEQfa8rMMrSy1NR17C2YpXaXkHbN1z",
+        "76a914e2a84cf6b6ac7ef17243fc64c145e08315e84b0d88ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "xWQdibr53r9P9apHcM1yvxXGF9m7SDJtK6",
-        "a914f2751d78a7dfb2fa9d305a4d724348411f6ab3d387",
+        "xJaJuiP69UEk2TsWbwqtSmBTzwzRaaqHYC",
+        "a91470a8109b687333af197b8ac500b94f07a6b0610287",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "pWXcVb2EqHSXv158HLNz8CE6vCdt9PTE2S",
-        "76a914120ca4205780a465d21f5166ca787ce10450ec5588ac",
+        "pssRdag58DiUyR7hJGQwZxcVYcYPVUuaz1",
+        "76a914fc2688d6e0c2414b7303f9ae389c7c6d3f03986788ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "rRbXe1d1PtbCCDzJQhoZi6ZzmXihp7gdje",
-        "a914d46036e41fefff032879e2739a9b633ffb9d3e5087",
+        "rKMPN5wHw8QttGqethJPyGf2Bmfg4yqo2Z",
+        "a9148fe2ba9e6aab69e28b8b6308e9f18f967ffa661687",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "4encvtSwnT1dq3tmZRJWH6CFfgojp9A81GbaRFNEri4YKbzYmqP",
-        "f375efef0cc2782d02c229bd4dafc2e4c73490535ebf18a9f4a910499a473002",
+        "4doYiXUCjLjekwhGbTeuCxKTy1AVJtJvhFkeMjyshCyB3Whs5hU",
+        "71decaba0693e9263119a0961151c3b717f749afb7d9156a82c798cc6048a031",
         {
             "chain": "main",
             "isCompressed": false,
@@ -57,8 +57,8 @@
         }
     ],
     [
-        "GzgjQJZFigkZx4dpCdhUCaUmxwkqVrgjAkhPRmpW78v4aZUkXi22",
-        "1fb4afd8a289d8b99dce1e94b0e0cc7581e43cf5d248408b6baa6e50d2e00d59",
+        "H2GXUD7YNpKY64ctbp8oxBQwpCWodHHmH6wtZdCyJEEN3UjyenLb",
+        "4eeda2143725c80be6d23ffdd57130ffa6351f2972cff227932bfec04f6c4dfd",
         {
             "chain": "main",
             "isCompressed": true,
@@ -66,8 +66,8 @@
         }
     ],
     [
-        "2YuSKAy7dkf6R5AEQZBX7UAWXbopozEV2ZabmuQ6vaGHJEL1jV3",
-        "40040d35cbfc9cede681cce4b8501fce24a99cdf05e1f5b53461469c2f084614",
+        "2ZHsya6ExQRwcRoYvy86ASKNjQXZGksJjWizVgKS3JT8UPWGCyT",
+        "72f96211324123046dd2794f3208bfc16f7afeaf54ee08f7040f0e23e5c965cc",
         {
             "chain": "test",
             "isCompressed": false,
@@ -75,8 +75,8 @@
         }
     ],
     [
-        "7tp1fd4RfqP5CEwcMt1K4u4xnTgdRL1LTRszTeMvGSkAr647w1aa",
-        "994e442abef57b253dea05f4d1ea447397be163deb5c316a9995f06d2c4f2fd2",
+        "7tYUZYGprqHCJ4fgeCjgqYoJpzL5XQBuWquXXDkg6qvbHkPHnYzC",
+        "9150328af1fb456c9ace19936fe07abfbf94ad063aa8419a8e8d0d53fd840fed",
         {
             "chain": "test",
             "isCompressed": true,
@@ -84,8 +84,8 @@
         }
     ],
     [
-        "2aGa75qpwQegc3UcEEZb5x5ivYXczd3UM5vxc5qacRU3VktEuzh",
-        "f3b334901663e493496b9b00761dba0ed41c4dbdecbb15cdf1e165c834b64d30",
+        "2ZNUgC2y3gyDjeKhWKtfeH2PDBbBoWexYos1T4rCWA71gYBzvdc",
+        "7d6a44e60f2e9370e2935ba83be5a95394b252faff3dd057fa012b3766b9d68f",
         {
             "chain": "regtest",
             "isCompressed": false,
@@ -93,8 +93,8 @@
         }
     ],
     [
-        "7toaqmaJ1U2CEM2a3JY5mibKUR5jrefQYRUFmCZ2GneRULvDtDvV",
-        "9915e5e03e67a34039d962258e198deb05628393d1e3ee38203cccec763bc4ea",
+        "7tFcFdrBPpxZewKV7cY4xGvqEiddNXAxnc54BhM4vkD9yJSVmXj2",
+        "88a2d3efd136522d1a6e1bd1414862b16c20fcd385bcd1d0de034c8ed79dfc10",
         {
             "chain": "regtest",
             "isCompressed": true,
@@ -102,8 +102,8 @@
         }
     ],
     [
-        "pw1qxxvu7p64zutwptc5yexhjx5rjh92z2zxrvlg7d",
-        "00143199cf07551716e0af14264d791a8395caa12846",
+        "pw1q2nsuzecafdp25c3jn90mmq9j2r0whvnjghj9yy",
+        "001454e1c1671d4b42aa6232995fbd80b250deebb272",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -111,8 +111,8 @@
         }
     ],
     [
-        "pw1qxqqzwj8e0q8amw6v92l3edcr34lk2066dxtvwv2957ccv5ty2x2sfw66ht",
-        "002030002748f9780fddbb4c2abf1cb7038d7f653f5a6996c73145a7b18651645195",
+        "pw1q9h3uwsxxwmw7k6v7hk4yw77m009cz5m7k49hh996qj5cs9dfukqstf07pu",
+        "00202de3c740c676ddeb699ebdaa477bdb7bcb81537eb54b7b94ba04a98815a9e581",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -120,8 +120,8 @@
         }
     ],
     [
-        "pw1pw5rqsuphsa",
-        "51027506",
+        "pw1purxse0u2ng",
+        "5102e0cd",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -129,8 +129,8 @@
         }
     ],
     [
-        "tgstw1q93pssv3jsvc6m2t0f3juxht54wpdh728spjg9w",
-        "00142c430832328331ada96f4c65c35d74ab82dbf947",
+        "tw1q58t84zh5eewns9qymlkf222ru30y22en49h9wg",
+        "0014a1d67a8af4ce5d381404dfec952943e45e452b33",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -138,8 +138,8 @@
         }
     ],
     [
-        "tgstw1qgn4g06mtjrujkmnxj97uvtjsv2a0w923gfr68vaa568suya37res2k7jv8",
-        "002044ea87eb6b90f92b6e66917dc62e5062baf715514247a3b3bda68f0e13b1f0f3",
+        "tw1qyh6v4y3ell6380vvgytnwr6953t8jxw904uaxj3rq8mwv7879l3s0krqpx",
+        "002025f4ca9239fff513bd8c4117370f45a4567919c57d79d34a2301f6e678fe2fe3",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -147,8 +147,8 @@
         }
     ],
     [
-        "tgstw1zpne659dwf7ftrwqlmygyucvcuu5mmw0a",
-        "52100cf3aa15ae4f92b1b81fd9104e6198e7",
+        "tw1z0nfm32vhkeslwz5ehys0jgtqvqe7j76y",
+        "52107cd3b8a997b661f70a99b920f9216060",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -156,8 +156,8 @@
         }
     ],
     [
-        "rtpw1qj3p2q8lctzewt5czgje3l40syyfwr5dv2xyche",
-        "00149442a01ff858b2e5d30244b31fd5f02112e1d1ac",
+        "rtpw1qwradu8yesjxz5z8xtagk96clwwgdnq4fg4tg3g",
+        "001470fade1c99848c2a08e65f5162eb1f7390d982a9",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -165,8 +165,8 @@
         }
     ],
     [
-        "rtpw1qyhcr3grsvxugs3ckwrtdxfx8l7xa348pqhl7lae2cmcahsla25vsa0v2ps",
-        "002025f038a07061b888471670d6d324c7ff8dd8d4e105ffeff72ac6f1dbc3fd5519",
+        "rtpw1qmlpdcsaumd2r2zej44hs3spxfw8axcn7vv2zm2gsu00r4ahtpkfqytqps7",
+        "0020dfc2dc43bcdb54350b32ad6f08c0264b8fd3627e63142da910e3de3af6eb0d92",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -174,8 +174,8 @@
         }
     ],
     [
-        "rtpw1skazesexrrl02rxr27k89tq48f37ez7a89ten2vwnlhwwgvpv0uheqen9f37qgpr0sl7k56",
-        "6028b7459864c31fdea1986af58e5582a74c7d917ba72af33531d3fddce4302c7f2f9066654c7c04046f",
+        "rtpw1s70k8vd5vnmpnms9hgt3cd7kxfan0eaq4zyn9ynrdzzu5vpnj8qweffygfxzhpx53sdnyny",
+        "6028f3ec76368c9ec33dc0b742e386fac64f66fcf4151126524c6d10b9460672381d94a4884985709a91",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -183,56 +183,56 @@
         }
     ],
     [
-        "PrXtbbFmUtmRgGac3mb23FJG3XJmtXZzyR",
-        "76a914cc16367dbbd010285f785e9ca8e2a8ca216c006b88ac",
+        "Pha5NGUnGTM4ZcBLhgy5UJ9PudpKCApypi",
+        "76a91469c6e73ee11ed4d3edfcd08bc630b3187bc672d988ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "RTCovFRZZpQ3KcsYC42M2PrDL6kYPAgZtA",
-        "a914c49e1a2af18a0e40dc780e7033a43524e632869487",
+        "R9apZmmHDauEBmTpbs5uGemXruMcGKc8md",
+        "a914035587813e24ba3f435c27dc95942be3930943d287",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "XYfs4U4EtoBgJnU1HWPXuC9xqqHWGVKy1m",
-        "76a914e9e05b7f08e29df37cee58de2a95139418119d9188ac",
+        "XRRACPKfP6EWoKyjcCVXZaXEYamoGwWzQg",
+        "76a9149a4f8ad7061cf9fe4a5e8b7a8404f5cefde6f04b88ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "xQqUuYxh2aHjRtGGLcq9Uix9ZNNVhgVnEX",
-        "a914b557677c745d07c6557ffb2658ba2f18e4b5934f87",
+        "xVyorW7cRqW6P3t7AUzDwWRdix8J8WGG5v",
+        "a914edc32d685f662402438654a9bd04adcbb753348887",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "pVXx8cR1ELQikY6NHXeh7GjopzV4C63SXh",
-        "76a9140724e899fae140343dc05e3d997584814403274088ac",
+        "pfy1688nTNWy8gDdoMG51NjJ1b6GzPw5fH",
+        "76a914799308b1314ae32c4b300f161c4d65632d3768ee88ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "rJYANHBU7ixt2Ca4t4wbEVrvKTH3B9Pqcc",
-        "a91486f4546807e0d4c124addb0e0e137430475c53d287",
+        "rQNgLkCyReXABom3RG1Tt2BY6kyi9WNsc5",
+        "a914c6f9f20982512eceec72ceff729160f1f2599fb487",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "4dng8ex8r6zJ6SXGzXbfDaT9oXDnpcadM7DE3GqTnr2BEA2QdgT",
-        "6fe3d619d2d083cb46ef9c55dee30384ecfaeb3ac4b0098336948492440005a5",
+        "4ep8hQs4YE1EkmVbXNeQSAQFFmzTvze9ayqoqLQPdomLfv83wVg",
+        "f6e58cbddef2463c13058da65f98bf3c0cf7876bd5f713ef15a11e7d93def6c1",
         {
             "chain": "main",
             "isCompressed": false,
@@ -240,8 +240,8 @@
         }
     ],
     [
-        "H3S6ZgbZF3bGUKvbHP2dfnWW1F7aaip1YPuQCfy6rZoYTABAnyzK",
-        "71b06a951e0780567968fa0680933fabe7ba20021d9adeb49dafe84d3f8fe4a5",
+        "H6HLWeArx72zLnWGLFX4XojkscBjfkJTAEuHPN1hmMqL4YHecWBZ",
+        "c6b1f112e1f1dc3881c988fb32ef54e4a087b40d114b6e1c72c81af805dc8376",
         {
             "chain": "main",
             "isCompressed": true,
@@ -249,8 +249,8 @@
         }
     ],
     [
-        "2ZhyHTMyfguEfaucJwNtM7SjYjLetMKDBKSNGfdMytKQKD7Cjbj",
-        "a9ad49876a4c3b44acb0f54165ef508cd08ba677a1d31bd4104fbbd3b9be6ea9",
+        "2YRUeji2qa2whns8JnQtHYxZTivNi7niVh6HSTd1FgoopRbXJ3K",
+        "0087a7cc3c43253811330e504045aa0627d18b445ae5e99838e1cc7caa78b07f",
         {
             "chain": "test",
             "isCompressed": false,
@@ -258,8 +258,8 @@
         }
     ],
     [
-        "7rJ1JwrjB85A17grXTEJALz8S2VshEFUeb36BujRQ4aADChwQ2By",
-        "4e31d3b18748029c06839b40f2c341eca964f71f4f6b94f276844e7a0509f851",
+        "7ujvCbyJSzqBgbCThzjNe6sJLiBo7Vxq725TvgpALggrLeXM6Q9Y",
+        "b50971cef5b878b8610f7da2343c152a5ee4f62970c85463f20342c9f7d55760",
         {
             "chain": "test",
             "isCompressed": true,
@@ -267,8 +267,8 @@
         }
     ],
     [
-        "2YfPJxxsz7a4d2TDqgZNiHASVEcWaA9FXJdTYs4cwfJjmjTvnEA",
-        "201c0a0abcc977506f2ba45ee50bc9b5d80502720d1ab33c4e7583e000eded91",
+        "2a9QiNvk2E6n7BskdbfdDo71P7z89Y7hERhQ8kv3Au3Zm17oKVG",
+        "e37020d3390b01a0507f7fb9b94e31681fa440aced453d0089ba10436dbae16d",
         {
             "chain": "regtest",
             "isCompressed": false,
@@ -276,8 +276,8 @@
         }
     ],
     [
-        "7pdKBfYyTXDGjBRYqqJUTggnoajYEpXePmKoeBQUDtaHYWV8Rt7i",
-        "1c73e44f6f21948ae945330ab77b4bb5dc0538775933fa37d8e00e3fa535347b",
+        "7rT8hxP2v4WvjgoUWSQZer7cW6NzJCcd7NzM4dk2zV25u33g4XwU",
+        "52e3e30cc670787390453bc569673113341641efbd6a34be28ad4469572ab9a4",
         {
             "chain": "regtest",
             "isCompressed": true,
@@ -285,8 +285,8 @@
         }
     ],
     [
-        "pw1qfg2qte8yrxne9jtyaxkhmhchrd5wjt4u2skx8x",
-        "00144a1405e4e419a792c964e9ad7ddf171b68e92ebc",
+        "pw1qvcfrjprfmg3g2e4knsydqe9yfqjnq6ag9h6pyj",
+        "00146612390469da228566b69c08d064a44825306ba8",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -294,8 +294,8 @@
         }
     ],
     [
-        "pw1qwcwhxkf2gcn6teneamcmtqeryp90wl8fkkf3uwl2p5ssgrka36lq90dtr9",
-        "0020761d73592a4627a5e679eef1b58323204af77ce9b5931e3bea0d21040edd8ebe",
+        "pw1qdgys8ee9nud8exa7tdmxrpt0vvuyymm4lyf9v74tvuyal67rnxrq3jl5yc",
+        "00206a0903e7259f1a7c9bbe5b7661856f6338426f75f912567aab6709dfebc39986",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -303,8 +303,8 @@
         }
     ],
     [
-        "pw1p62zsrn4uts",
-        "5102d285",
+        "pw1prahsxmp07f",
+        "51021f6f",
         {
             "chain": "main",
             "isPrivkey": false,
@@ -312,8 +312,8 @@
         }
     ],
     [
-        "tgstw1q54hnmuyc5ntpe5xt0gcs0pygln3zt6hpfnk7p0",
-        "0014a56f3df098a4d61cd0cb7a31078488fce225eae1",
+        "tw1qflq35kllw9z89jy98ntc7km5fzaxzhekglwej2",
+        "00144fc11a5bff714472c8853cd78f5b7448ba615f36",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -321,8 +321,8 @@
         }
     ],
     [
-        "tgstw1qn223xdhurgrtxvngyyg9te5nrlnwjfz230pe0wtkya7va5xpc5gqh0ddy7",
-        "00209a951336fc1a06b33268211055e6931fe6e9244a8bc397b976277cced0c1c510",
+        "tw1qyuzq2dz687952wsxa7vvfgqez8044ltpfw5s8e7wwtgm00d0exqshykqux",
+        "0020270405345a3f8b453a06ef98c4a01911df5afd614ba903e7ce72d1b7bdafc981",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -330,8 +330,8 @@
         }
     ],
     [
-        "tgstw1z7s3k9x73psz579msep6y690uccas4rl2",
-        "5210f423629bd10c054f1770c8744d15fcc6",
+        "tw1zsylhst7ckznkr0l3vreurym06g377qye",
+        "5210813f782fd8b0a761bff160f3c1936fd2",
         {
             "chain": "test",
             "isPrivkey": false,
@@ -339,8 +339,8 @@
         }
     ],
     [
-        "rtpw1qxmg0n0zk2dafp6zdeypvwtjfutl8wurl0k9nmg",
-        "001436d0f9bc56537a90e84dc902c72e49e2fe77707f",
+        "rtpw1q9w0d72wsvdllq4huvnan62ef82gutqnf7afcre",
+        "00142b9edf29d0637ff056fc64fb3d2b293a91c58269",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -348,8 +348,8 @@
         }
     ],
     [
-        "rtpw1qjh5dcs32ddf695kfjlyhxach4cz0tgalaxm9qenlvj8m6e4668rqpammhh",
-        "002095e8dc422a6b53a2d2c997c9737717ae04f5a3bfe9b650667f648fbd66bad1c6",
+        "rtpw1qgtj6tqpm9l6ddv4vx9pkwqccwd526ldyjhqfeszngzx9ee972h9q7avwgq",
+        "002042e5a5803b2ff4d6b2ac31436703187368ad7da495c09cc053408c5ce4be55ca",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -357,8 +357,8 @@
         }
     ],
     [
-        "rtpw1sx9msdzhffrgcjjw7ujz7lvw65w4dvjwsj2rk7heny7kuhvz472u5kcghmpe9wmpyxaejqx",
-        "60283177068ae948d18949dee485efb1daa3aad649d092876f5f3327adcbb055f2b94b6117d872576c24",
+        "rtpw1s5jzxvpwhw8dmt4l4rhalxgqrarhqmkxt68fgrwv4ygx4zt6fst0a5cm3zczmzcrsaaa6tn",
+        "6028a4846605d771dbb5d7f51dfbf32003e8ee0dd8cbd1d281b995220d512f4982dfda63711605b16070",
         {
             "chain": "regtest",
             "isPrivkey": false,
@@ -366,56 +366,56 @@
         }
     ],
     [
-        "PqNuovT1N6beR8HDz34XQrWgR7gWECjtE2",
-        "76a914bf6b5b0b9559052fd0dab75e81e01b26dede4f9088ac",
+        "PrD2iYxvtd8TcyHVUMKJGt1R5HxdH8aknM",
+        "76a914c885167ba3527e9dd081690d3a547ad765fdec4c88ac",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "RDM6BKNvKSLPcfNUTSkks26qjVd4AZ2t7Y",
-        "a9142c9d3def5b3526088d061710517ab240438abf2f87",
+        "RN1VW98jb6oP5Ub6cExtsCMga6a5mvnbTU",
+        "a9148ba1866cd179860e5340af4d59f713a880be1a7287",
         {
             "chain": "main",
             "isPrivkey": false
         }
     ],
     [
-        "XDfd8cmHXP7P8rSu2ApA22zP7GoxhdkUm9",
-        "76a914196a5733cd3d623b6886df03e2b6a9948e965e9d88ac",
+        "XVxQhv5A7ojQda3eDJmQujdaB7Yr5ySESV",
+        "76a914cc190d4a4c5c6501a14d974f50ae254e5146a84b88ac",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "xBnptCfxPYiCY63BQHYzuP2kJmA86FpZ3w",
-        "a914263d326815113a1e94395d95da906f23b926ab0b87",
+        "xFkyGsVqHmzcCtumMVq39dTZz8HDGDHVYy",
+        "a91451c3df58652c6e60a9f7e4ec61b9043dff8c67fe87",
         {
             "chain": "test",
             "isPrivkey": false
         }
     ],
     [
-        "ppV6Doq6ET8RYBJou96uHVFK3qRupzTcFH",
-        "76a914d704cdafd421b027228c0773dade6aea853af3e488ac",
+        "pjyHkB8kT1rBfmA3XTEMzj38SuH6fHSJtS",
+        "76a914a58170dceaa0fc959304ee2676edc0153907b9fc88ac",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "r9mkCAEJtBUhnrycbLXHvw9eAhQuUV1Guk",
-        "a91426ccd75e5e733392f2ad1b4054b2c6ceeb0a8ae187",
+        "r8zvXgYJdsbxLswbtEUBj4nFn5HGLJ9Kdd",
+        "a9141e52c066312e56a220596b4ef8ddfc285fc4ddbc87",
         {
             "chain": "regtest",
             "isPrivkey": false
         }
     ],
     [
-        "4e3mpJEDHcWwz4mM1Gj2gFa5xEWK5JxHzfcaxVZXjJrC2S5UbGD",
-        "922bfc84dd857aa0964750157e31f61f4c58f84c8eeb27cf823738332e75c54a",
+        "4du8cYHMEFfwhr2Atdx14FUkDtNQi3ovFFwH25ym3TGBXHYy4YQ",
+        "7e8ce77261f9faf40edd89a41062e21b8656a1cae1615d5949a9e2f2b0e964b0",
         {
             "chain": "main",
             "isCompressed": false,
@@ -423,8 +423,8 @@
         }
     ],
     [
-        "H1rjeyJX5CF1PC8RVUxEa9xWc1mnWUXkfFaein7ALPZYCcRNFpmr",
-        "42b0987a34b261ad54b3b7a85457702b84185a7ee84f7c5682ecb3b346fd3458",
+        "H7518zXYxobHC2rKX9ZQxWuXjwQHYyJUye7HSHSZRfp5gaZMfFf9",
+        "de2ff90476ec7baeb521d5041998f365e1747ee11dd26de72a03b9eb4e25b8d4",
         {
             "chain": "main",
             "isCompressed": true,


### PR DESCRIPTION
For issue https://github.com/ghost-coin/ghost-private/issues/26

As we discussed in chat we will have the prefix `ghost` for the mainnet, `tghost` for the testnet and `rghost` for the mainnet.
I think we are interested only on the addresses generated(please correct me if i am wrong) so we can keep the other prefixes the same or simple. This PR changes the testnet and the regtest address prefixes. It does not change the mainnet(due to additional test failure that should be researched in a new PR).

The same tests as https://github.com/ghost-coin/ghost-private/pull/25 were done, all passing except the ones that were failing before prefix changes. 

Let me know what do you think.
