### PR TITLE
[Params] Remove SetLastImportHeight

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -388,7 +388,6 @@ public:
         nTargetTimespan = 24 * 60;      // 24 mins
         nBlockReward = 6 * COIN;
         nBlockPerc = {100, 100, 95, 90, 86, 81, 77, 74, 70, 66, 63, 60, 57, 54, 51, 49, 46, 44, 42, 40, 38, 36, 34, 32, 31, 29, 28, 26, 25, 24, 23, 21, 20, 19, 18, 17, 17, 16, 15, 14, 14, 13, 12, 12, 11, 10, 10};
-        SetLastImportHeight();
 
         nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 1;
@@ -558,8 +557,6 @@ public:
         nBlockReward = 6 * COIN;
         nBlockPerc = {100, 100, 95, 90, 86, 81, 77, 74, 70, 66, 63, 60, 57, 54, 51, 49, 46, 44, 42, 40, 38, 36, 34, 32, 31, 29, 28, 26, 25, 24, 23, 21, 20, 19, 18, 17, 17, 16, 15, 14, 14, 13, 12, 12, 11, 10, 10};
 
-        SetLastImportHeight();
-
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 1;
         m_assumed_chain_state_size = 1;
@@ -701,8 +698,6 @@ public:
         nStakeTimestampMask = 0;
         nBlockReward = 6 * COIN;
         nBlockPerc = {100, 100, 95, 90, 86, 81, 77, 74, 70, 66, 63, 60, 57, 54, 51, 49, 46, 44, 42, 40, 38, 36, 34, 32, 31, 29, 28, 26, 25, 24, 23, 21, 20, 19, 18, 17, 17, 16, 15, 14, 14, 13, 12, 12, 11, 10, 10};
-
-        SetLastImportHeight();
 
         nPruneAfterHeight = 1000;
         m_assumed_blockchain_size = 0;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -159,11 +159,6 @@ public:
 protected:
     CChainParams() {}
 
-    void SetLastImportHeight()
-    {
-        nLastImportHeight = 0;
-    }
-
     Consensus::Params consensus;
     CMessageHeader::MessageStartChars pchMessageStart;
     int nDefaultPort;
@@ -177,7 +172,7 @@ protected:
     uint32_t nStakeTimestampMask = (1 << 4) -1; // 4 bits, every kernel stake hash will change every 16 seconds
     int64_t nCoinYearReward = 2 * CENT; // 2% per year
     std::array<int, 47> nBlockPerc; //reward percentage each year
-    uint32_t nLastImportHeight;       // always 0 on ghost
+    uint32_t nLastImportHeight = 0;       // always 0 on ghost
 
     std::vector<std::pair<int64_t, DevFundSettings> > vDevFundSettings;
 


### PR DESCRIPTION
On Ghost we dont make use of import coinbase txes,this PR Removes the redundant SetLastImportHeight func , its calls in chainparams and instead sets the lastimportheight in chainparams.h to 0.