### PR TITLE
[Params] Update Ext key prefixes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -417,8 +417,8 @@ public:
         base58Prefixes[PUBKEY_ADDRESS_256] = {0x39};
         base58Prefixes[SCRIPT_ADDRESS_256] = {0x3d};
         base58Prefixes[SECRET_KEY]         = {0xA6}; //PUBKEY_ADDRESS Prefix in int + 128 converted to hexadecimal
-        base58Prefixes[EXT_PUBLIC_KEY]     = {0x04, 0x88, 0xB2, 0x1E}; // XPUB
-        base58Prefixes[EXT_SECRET_KEY]     = {0x04, 0x88, 0xAD, 0xE4}; // XPRV
+        base58Prefixes[EXT_PUBLIC_KEY]     = {0x68, 0xDF, 0x7C, 0xBD}; // PGHST
+        base58Prefixes[EXT_SECRET_KEY]     = {0x8E, 0x8E, 0xA8, 0xEA}; // XGHST
         base58Prefixes[STEALTH_ADDRESS]    = {0x14};
         base58Prefixes[EXT_KEY_HASH]       = {0x4b}; // X
         base58Prefixes[EXT_ACC_HASH]       = {0x17}; // A


### PR DESCRIPTION
This PR changes prefixes for ext public and secret keys to PGHST and XGHST.This is done to avoid conflict with the ext prefixes of btc.

I have tested and verified that this change does not cause issues with balance after restoring with mnemonic,both on last release and binaries compiled with this change.