### PR TITLE
[RPC][WIP] Fix sendmany when executed with duplicate addrs with varying amounts.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1115,11 +1115,16 @@ static UniValue sendmany(const JSONRPCRequest& request)
         UniValue arr(UniValue::VARR);
 
         std::vector<std::string> keys = sendTo.getKeys();
-        for (const std::string& name_ : keys) {
+        
+        for(std::size_t i=0; i < keys.size(); ++i) {
             UniValue out(UniValue::VOBJ);
+            
+            // Give the option to send funds to the same address with different amounts
+            std::string const& name_ = keys[i];
+            UniValue const& amount= sendTo[i];
 
             out.pushKV("address", name_);
-            out.pushKV("amount", sendTo[name_]);
+            out.pushKV("amount", amount);
 
             bool fSubtractFeeFromAmount = false;
             for (unsigned int idx = 0; idx < subtractFeeFromAmount.size(); idx++) {


### PR DESCRIPTION
previously `sendmany` was using the addr as the key, without any warnings of duplicates. this func would send the first value amount found based on that addr key. so if you wanted to send 2 transactions using the same address"  `{ addr1:amt1, addr1:amt2}` this command would only use amt1 and create a transaction that looked like `{addr1: amt1, addr1: amt1}`.

in bitcoin-core there would at least be a notification of duplicate. not sure why that warning wasn't implemented here previously? nonetheless this fixed it by using an index as the key to reference the keypair and valuepair without modifying the `UniValue` base class.
