### PR TITLE
[RPC] Add burn command

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -184,7 +184,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "tallyvotes", 1, "height_start" },
     { "tallyvotes", 2, "height_end" },
 
-
+    { "burn", 0, "amount" },
     { "sendghosttoblind", 1, "amount" },
     { "sendghosttoblind", 4, "subtractfeefromamount" },
     { "sendghosttoanon", 1, "amount" },

--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -4585,7 +4585,28 @@ static int AddOutput(uint8_t nType, std::vector<CTempRecipient> &vecSend, const 
     vecSend.push_back(r);
     return 0;
 };
+static int AddOutputScript(uint8_t nType, std::vector<CTempRecipient> &vecSend, const CScript &script, CAmount nValue,
+    bool fSubtractFeeFromAmount, std::string &sNarr, std::string &sBlind, std::string &sError)
+{
+    CTempRecipient r;
+    r.nType = nType;
+    r.SetAmount(nValue);
+    r.fSubtractFeeFromAmount = fSubtractFeeFromAmount;
+    r.fScriptSet = true;
+    r.scriptPubKey = script;
+    r.sNarration = sNarr;
 
+    if (!sBlind.empty()) {
+        uint256 blind;
+        blind.SetHex(sBlind);
+
+        r.vBlind.resize(32);
+        memcpy(r.vBlind.data(), blind.begin(), 32);
+    }
+
+    vecSend.push_back(r);
+    return 0;
+};
 void ReadCoinControlOptions(const UniValue &obj, CHDWallet *pwallet, CCoinControl &coin_control)
 {
     if (obj.exists("changeaddress")) {
@@ -5017,7 +5038,6 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
         // This can happen if the mempool rejected the transaction.  Report
         // what happened in the "errors" response.
         vErrors.push_back(strprintf("Error: The transaction was rejected: %s", FormatStateMessage(state)));
-
         UniValue result(UniValue::VOBJ);
         result.pushKV("txid", wtx.GetHash().GetHex());
         result.pushKV("errors", vErrors);
@@ -5033,6 +5053,85 @@ static UniValue SendToInner(const JSONRPCRequest &request, OutputTypes typeIn, O
     } else {
         return wtx.GetHash().GetHex();
     }
+}
+
+static UniValue SendToScriptInner(const JSONRPCRequest &request, CScript script = CScript())
+{
+   std::shared_ptr < CWallet>
+   const wallet = GetWalletForJSONRPCRequest(request);
+   CHDWallet *const pwallet = GetParticlWallet(wallet.get());
+   if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+   {
+      return NullUniValue;
+   }
+
+   // Make sure the results are valid at least up to the most recent block
+   // the user could have gotten from another RPC command prior to now
+   if (!request.fSkipBlock)
+   {
+      pwallet->BlockUntilSyncedToCurrentChain();
+   }
+
+   EnsureWalletIsUnlocked(pwallet);
+
+   if (pwallet->GetBroadcastTransactions() && !g_connman)
+   {
+      throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+   }
+
+   CAmount nTotal = 0;
+
+   std::vector<CTempRecipient> vecSend;
+   std::string sError;
+
+   CAmount nAmount = AmountFromValue(request.params[0]);
+   if (nAmount <= 0)
+   {
+      throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
+   }
+   nTotal += nAmount;
+
+   bool fSubtractFeeFromAmount = false;
+   std::string sNarr;  //Empty for
+   std::string sBlind;   // Always empty
+
+   if (0 != AddOutputScript(OUTPUT_STANDARD, vecSend, script, nAmount, fSubtractFeeFromAmount, sNarr, sBlind, sError))
+   {
+      throw JSONRPCError(RPC_MISC_ERROR, strprintf("AddOutput failed: %s.", sError));
+   }
+
+   const auto bal = pwallet->GetBalance();
+   if (nTotal > bal.m_mine_trusted){
+      throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient funds");
+   }
+
+   // Wallet comments
+   CTransactionRef tx_new;
+   CWalletTx wtx(pwallet, tx_new);
+   CTransactionRecord rtx;
+
+   bool fShowHex = false;
+   bool fShowFee = false;
+   bool fCheckFeeOnly = false;
+
+   CCoinControl coincontrol;
+   coincontrol.m_avoid_address_reuse = pwallet->IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE);
+   coincontrol.m_avoid_partial_spends |= coincontrol.m_avoid_address_reuse;
+
+   CAmount nFeeRet = 0;
+   {
+      auto locked_chain = pwallet->chain().lock();
+      LockAssertion lock(::cs_main);
+      if (0 != pwallet->AddStandardInputs(*locked_chain, wtx, rtx, vecSend, !fCheckFeeOnly, nFeeRet, &coincontrol, sError))
+         throw JSONRPCError(RPC_WALLET_ERROR, strprintf("AddStandardInputs failed: %s.", sError));
+   }
+
+   CValidationState state;
+   if (!pwallet->CommitTransaction(wtx.tx, wtx.mapValue, wtx.vOrderForm, state)){
+      throw JSONRPCError(RPC_WALLET_ERROR, strprintf("Transaction commit failed: %s", FormatStateMessage(state)));
+   }
+   pwallet->PostProcessTempRecipients(vecSend);
+   return wtx.GetHash().GetHex();
 }
 
 static const char *TypeToWord(OutputTypes type)
@@ -5204,6 +5303,34 @@ static UniValue sendanontoanon(const JSONRPCRequest &request)
 
     return SendToInner(request, OUTPUT_RINGCT, OUTPUT_RINGCT);
 };
+
+static UniValue burn(const JSONRPCRequest &request){
+        RPCHelpMan{"burn",
+                "\nBurns the amount of coins by sending it to OP_RETURN.\n",
+                {
+                    {"amount", RPCArg::Type::NUM, RPCArg::Optional::NO, "The Amount to burn"},
+                    {"data", RPCArg::Type::STR, /* default */ "", "Optional string data to add with OP_RETURN"}
+                },
+                RPCResult{
+                    "TxHash"
+                },
+                RPCExamples{
+            HelpExampleCli("burn", "10 \"Rewardburn\"") +
+            "\nAs a JSON-RPC call\n"
+            + HelpExampleRpc("burn", "10 ,\"Rewardburn\"")
+                },
+            }.Check(request);
+
+    //Prepare script
+    CScript burnScript = CScript() << OP_RETURN;
+    if (request.params.size() > 1 && !request.params[1].isNull() && !request.params[1].get_str().empty()) {
+        if (request.params[1].get_str().length() > 80)
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Comment cannot be longer than 80 characters");
+        burnScript << ToByteVector(request.params[1].get_str());
+    }
+
+    return SendToScriptInner(request,burnScript);
+}
 
 UniValue sendtypeto(const JSONRPCRequest &request)
 {
@@ -8373,6 +8500,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listunspentanon",                  &listunspentanon,               {"minconf","maxconf","addresses","include_unsafe","query_options"} },
     { "wallet",             "listunspentblind",                 &listunspentblind,              {"minconf","maxconf","addresses","include_unsafe","query_options"} },
 
+    { "wallet",             "burn",                             &burn,                          {"amount","data"} },
 
     //sendghosttoghost // normal txn
     { "wallet",             "sendghosttoblind",                  &sendghosttoblind,               {"address","amount","comment","comment_to","subtractfeefromamount","narration"} },

--- a/test/functional/rpc_part_burn.py
+++ b/test/functional/rpc_part_burn.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2019 The Particl Core developers
+# Copyright (c) 2020 The Ghost Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_particl import ParticlTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+
+
+class WalletRPCBurnTest(ParticlTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [ ['-debug'] for i in range(self.num_nodes)]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def setup_network(self, split=False):
+        self.add_nodes(self.num_nodes, extra_args=self.extra_args)
+        self.start_nodes()
+
+        self.sync_all()
+
+    def run_test(self):
+        nodes = self.nodes
+
+        nodes[0].extkeyimportmaster('abandon baby cabbage dad eager fabric gadget habit ice kangaroo lab absorb')
+        assert(nodes[0].getwalletinfo()['total_balance'] == 100000)
+
+        #Burn 100 coins with op_return text as burntx
+        nodes[0].burn(100,"burntx")
+        #Check max char limit
+        assert_raises_rpc_error(-8, "Comment cannot be longer than 80 characters", self.nodes[0].burn,1,"The clock within this blog and the clock on my laptop are 1 hour different from each other.")
+        #Check burning works without any comment
+        nodes[0].burn(1)
+
+        self.sync_all()
+
+
+if __name__ == '__main__':
+    WalletRPCBurnTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -238,6 +238,7 @@ PARTICL_SCRIPTS = [
     'feature_part_vote.py',
     'feature_part_zmq_test.py',
     'rpc_part_wallet.py',
+    'rpc_part_burn.py',
     'feature_part_usbdevice.py',
     'wallet_part_watchonly.py',
     'rpc_part_atomicswap.py',


### PR DESCRIPTION
This PR adds the burn RPC command to rpchdwallet.cpp with the following changes:
- Add SendToScriptInner and test cases for burn command
- Fix lint failure due to tabs in new function code
- Remove unused imports in burn functional test
- Add back removed Univalue include
- Add burn to RPC using OP_RETURN as destination with optional hex encoded string.
