### PR TITLE
adjust the devFund payment to be paid to a GVR-operated address

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -62,22 +62,12 @@ int64_t CChainParams::GetMaxSmsgFeeRateDelta(int64_t smsg_fee_prev) const
     return (smsg_fee_prev * consensus.smsg_fee_max_delta_percent) / 1000000;
 };
 
-const DevFundSettings *CChainParams::GetDevFundSettings(int64_t nTime,int nHeight) const
+const DevFundSettings *CChainParams::GetDevFundSettings(int nHeight) const
 {
-    //TODO akshaynexus cleanup this code
-    if(nHeight >= consensus.nBlockRewardIncreaseHeight){
-        for (auto i = vDevFundSettingsNew.rbegin(); i != vDevFundSettingsNew.rend(); ++i) {
-            if (nTime > i->first) {
-                return &i->second;
-            }
-        }
-    }
-    else{
-        for (auto i = vDevFundSettings.rbegin(); i != vDevFundSettings.rend(); ++i) {
-            if (nTime > i->first) {
-                return &i->second;
-            }
-        }
+    for (auto i = vDevFundSettings.begin(); i != vDevFundSettings.end(); ++i) {
+         if (nHeight >= i->first) {
+             return &i->second;
+         }
     }
 
     return nullptr;
@@ -426,13 +416,9 @@ public:
         vSeeds.emplace_back("ghostseeder.coldstake.io");
         vSeeds.emplace_back("ghostseeder.ghostbyjohnmcafee.com");
 
-        //DevFund settings before gvr addition
-        vDevFundSettings.emplace_back(0,
-            DevFundSettings("GQtToV2LnHGhHy4LRVapLDMaukdDgzZZZV", 33.00, 360));//Approx each 12 hr payment to dev fund
-
-        //Dev fee new settings
-        vDevFundSettingsNew.emplace_back(0,
-            DevFundSettings("Ga7ECMeX8QUJTTvf9VUnYgTQUFxPChDqqU", 66.67, 5040));//Approx each week to GVR Funds addr
+        vDevFundSettings.emplace_back(139456, DevFundSettings("GQJ4unJi6hAzd881YM17rEzPNWaWZ4AR3f", 66.67, 5040)); //As above but to a GVR held addr
+        vDevFundSettings.emplace_back(40862,  DevFundSettings("Ga7ECMeX8QUJTTvf9VUnYgTQUFxPChDqqU", 66.67, 5040)); //Approx each week to GVR Funds addr
+        vDevFundSettings.emplace_back(0,      DevFundSettings("GQtToV2LnHGhHy4LRVapLDMaukdDgzZZZV", 33.00, 360));  //Approx each 12 hr payment to dev fund
 
         base58Prefixes[PUBKEY_ADDRESS]     = {0x26}; // G
         base58Prefixes[SCRIPT_ADDRESS]     = {0x61}; // g
@@ -603,8 +589,8 @@ public:
         // nodes with support for servicebits filtering should be at the top
         vSeeds.emplace_back("ghost-testnetdns.mineit.io");
 
-        vDevFundSettings.push_back(std::make_pair(0, DevFundSettings("XHjYLwbVGbhr96HZqhT7j8crjEZJiGdZ1B", 33.00, 1440)));
-        vDevFundSettingsNew.push_back(std::make_pair(0, DevFundSettings("XHjYLwbVGbhr96HZqhT7j8crjEZJiGdZ1B", 66.67, 100)));
+        vDevFundSettings.push_back(std::make_pair(46863, DevFundSettings("XHjYLwbVGbhr96HZqhT7j8crjEZJiGdZ1B", 66.67, 100)));
+        vDevFundSettings.push_back(std::make_pair(0,     DevFundSettings("XHjYLwbVGbhr96HZqhT7j8crjEZJiGdZ1B", 33.00, 1440)));
 
         base58Prefixes[PUBKEY_ADDRESS]     = {0x4B}; // X
         base58Prefixes[SCRIPT_ADDRESS]     = {0x89}; // x

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -395,6 +395,7 @@ public:
         consensus.nBlockRewardIncreaseHeight = 40862;
         consensus.nGVRPayOnetimeAmt = 129000 * COIN;
         consensus.nOneTimeGVRPayHeight = 42308;//Approx Tuesday,August 25,2020,Time: 12:50 PM GMT +3
+        consensus.nGVRDevFundAdjustment = 139456;
         nBlockRewardIncrease = 2;       // Times to increase blockreward
         nBlockPerc = {100, 100, 95, 90, 86, 81, 77, 74, 70, 66, 63, 60, 57, 54, 51, 49, 46, 44, 42, 40, 38, 36, 34, 32, 31, 29, 28, 26, 25, 24, 23, 21, 20, 19, 18, 17, 17, 16, 15, 14, 14, 13, 12, 12, 11, 10, 10};
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -103,8 +103,8 @@ public:
     uint32_t GetStakeTimestampMask(int /*nHeight*/) const { return nStakeTimestampMask; }
     int64_t GetBaseBlockReward() const;
     int GetCoinYearPercent(int year) const;
-    const DevFundSettings *GetDevFundSettings(int64_t nTime,int nHeight) const;
-    const std::vector<std::pair<int64_t, DevFundSettings> > &GetDevFundSettings() const {return vDevFundSettings;};
+    const DevFundSettings *GetDevFundSettings(int nHeight) const;
+    const std::vector<std::pair<int64_t, DevFundSettings> > &GetDevFundSettings() const { return vDevFundSettings; };
 
     CAmount GetProofOfStakeReward(const CBlockIndex *pindexPrev, int64_t nFees) const;
     CAmount GetProofOfStakeRewardAtYear(int year) const;
@@ -177,8 +177,6 @@ protected:
     uint32_t nLastImportHeight = 0;       // always 0 on ghost
 
     std::vector<std::pair<int64_t, DevFundSettings> > vDevFundSettings;
-    std::vector<std::pair<int64_t, DevFundSettings> > vDevFundSettingsNew;
-
 
     uint64_t nPruneAfterHeight;
     uint64_t m_assumed_blockchain_size;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -115,6 +115,8 @@ struct Params {
     int nBlockRewardIncreaseHeight;
     //GVR Allocation one time payout params
     int nOneTimeGVRPayHeight;
+    //GVR Devfund Adjustment to a GVR held address
+    int nGVRDevFundAdjustment;
     int64_t nGVRPayOnetimeAmt;
     // Params for Zawy's LWMA difficulty adjustment algorithm.
     int64_t nZawyLwmaAveragingWindow;

--- a/src/insight/rpc.cpp
+++ b/src/insight/rpc.cpp
@@ -1040,7 +1040,7 @@ UniValue getblockreward(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_MISC_ERROR, "Block not found on disk");
     }
 
-    const DevFundSettings *devfundconf = Params().GetDevFundSettings(pblockindex->GetBlockTime(),pblockindex->nHeight);
+    const DevFundSettings *devfundconf = Params().GetDevFundSettings(pblockindex->nHeight);
     CScript devFundScriptPubKey;
     if (devfundconf) {
         CTxDestination dest = DecodeDestination(devfundconf->sDevFundAddresses);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2220,15 +2220,16 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             pfrom->fDisconnect = true;
             return false;
         }
-        int nMinPeerVer = MIN_PEER_PROTO_VERSION;
-        if(pindexBestHeader->nHeight >= Params().GetConsensus().nOneTimeGVRPayHeight)
-            nMinPeerVer = PROTOCOL_VERSION;
-        if (nVersion < nMinPeerVer) {
+
+        //! GVR devFund Adjustment
+        const bool devFundDissociate = pindexBestHeader->nHeight >= chainparams.GetConsensus().nGVRDevFundAdjustment;
+        const int nMinPeerVersion = devFundDissociate ? PROTOCOL_VERSION : MIN_PEER_PROTO_VERSION;
+        if (nVersion < nMinPeerVersion) {
             // disconnect from peers older than this proto version
             LogPrint(BCLog::NET, "peer=%d using obsolete version %i; disconnecting\n", pfrom->GetId(), nVersion);
             if (enable_bip61) {
                 connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE,
-                                   strprintf("Version must be %d or greater", nMinPeerVer)));
+                                     strprintf("Version must be %d or greater", nMinPeerVersion)));
             }
             pfrom->fDisconnect = true;
             return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2842,7 +2842,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
         if (block.IsProofOfStake()) { // Only the genesis block isn't proof of stake
             CTransactionRef txCoinstake = block.vtx[0];
             CTransactionRef txPrevCoinstake = nullptr;
-            const DevFundSettings *pDevFundSettings = chainparams.GetDevFundSettings(block.nTime,pindex->nHeight);
+            const DevFundSettings *pDevFundSettings = chainparams.GetDevFundSettings(pindex->nHeight);
             const CAmount nCalculatedStakeReward = Params().GetProofOfStakeReward(pindex->pprev, nFees); // stake_test
             const float nCalculatedStakeRewardReal = (float) nCalculatedStakeReward / COIN; // stake_test
 

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 90012;
+static const int PROTOCOL_VERSION = 90013;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;

--- a/src/wallet/hdwallet.cpp
+++ b/src/wallet/hdwallet.cpp
@@ -12643,7 +12643,7 @@ bool CHDWallet::CreateCoinStake(unsigned int nBits, int64_t nTime, int nBlockHei
     // Process development fund
     CTransactionRef txPrevCoinstake = nullptr;
     CAmount nRewardOut;
-    const DevFundSettings *pDevFundSettings = Params().GetDevFundSettings(nTime,pindexPrev->nHeight + 1);
+    const DevFundSettings *pDevFundSettings = Params().GetDevFundSettings(pindexPrev->nHeight + 1);
     if (!pDevFundSettings || pDevFundSettings->nMinDevStakePercent <= 0) {
         nRewardOut = nReward;
     } else {

--- a/src/wallet/rpchdwallet.cpp
+++ b/src/wallet/rpchdwallet.cpp
@@ -3962,7 +3962,7 @@ static UniValue getstakinginfo(const JSONRPCRequest &request)
         obj.pushKV("walletfoundationdonationpercent", pwallet->nWalletDevFundCedePercent);
     }
 
-    const DevFundSettings *pDevFundSettings = Params().GetDevFundSettings(nTipTime,::ChainActive().Tip()->nHeight);
+    const DevFundSettings *pDevFundSettings = Params().GetDevFundSettings(::ChainActive().Tip()->nHeight);
     if (pDevFundSettings && pDevFundSettings->nMinDevStakePercent > 0) {
         obj.pushKV("foundationdonationpercent", pDevFundSettings->nMinDevStakePercent);
     }


### PR DESCRIPTION
As discussed with Joe/Ghost Veterans, the devFund is to be adjusted to pay GQJ4unJi6hAzd881YM17rEzPNWaWZ4AR3f from block 139456 onwards. Additionally the existing client will dissociate away at this blockheight.